### PR TITLE
修复弃牌相关的bug，同时不让公正女神发出CardDown事件

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -130,7 +130,7 @@ namespace Cynthia.Card
         {
             return ToCemetery(discardInfo: (false, null), isRoundEnd: false, type: type, isNeedBanish: isNeedBanish, isNeedSentEvent: isNeedSentEvent);
         }
-        private async Task ToCemetery((bool isDiscard, GameCard discardSource) discardInfo, bool isRoundEnd, CardBreakEffectType type = CardBreakEffectType.ToCemetery, bool isNeedBanish = true, bool isNeedSentEvent = false)
+        private async Task ToCemetery((bool isDiscard, GameCard discardSource) discardInfo, bool isRoundEnd, CardBreakEffectType type = CardBreakEffectType.ToCemetery, bool isNeedBanish = true, bool isNeedSentEvent = true)
         {
             var isDead = Card.Status.CardRow.IsOnPlace();
             var deadposition = Game.GetCardLocation(Card);

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Neutral/Gold/LandOfAThousandFables.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Neutral/Gold/LandOfAThousandFables.cs
@@ -41,10 +41,8 @@ namespace Cynthia.Card
                     if (location.RowPosition.IsOnPlace())
                     {
                         await Game.ShowCardOn(Card);
-                        await Game.AddTask(async () =>
-                        {
-                            await CardDown(false, false, false, (false, false));
-                        });
+                        await Game.ShowCardDown(Card);
+                        await Game.SetPointInfo();
                     }
                     // 清理战场时会被放逐
                     Card.Status.IsDoomed = true;


### PR DESCRIPTION
1. 现在弃牌效果无法发动，原因是默认的ToCemetery的isNeedSentEvent 为false
2. 不让公正女神发出CardDown事件，改为ShowCardDown和SetPointInfo