### PR TITLE
修复哈蒙德无法取消血月中后续打出的单位收到的伤害的bug

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/RowEffect/BloodMoonStatus.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/RowEffect/BloodMoonStatus.cs
@@ -12,7 +12,7 @@ namespace Cynthia.Card
             var target = @event.Target;
             if (target.PlayerIndex == PlayerIndex && target.Status.CardRow == RowPosition)
             {
-                await target.Effect.Damage(2, null);
+                await target.Effect.Damage(2, null, damageType: DamageType.BloodMoon);
             }
         }
 


### PR DESCRIPTION
修复哈蒙德无法取消血月中后续打出的单位收到的伤害的bug

修复方法为：给血月的AfterUnitDown里的damage补上伤害类型