### PR TITLE
修改了巨章鱼怪与倾盆大雨，添加了“70019卓尔坦·矮人战士，70020菲吉斯·梅鲁佐，70021穆罗·布鲁伊斯，70022齐齐摩战士，70023齐齐摩工兵”5张卡牌

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/KikimoreWarrior.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/KikimoreWarrior.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70023")]//齐齐摩战士
+    public class KikimoreWarrior : CardEffect
+    {
+        //吞噬己方牌组中1个战力不大于自身的非同名铜色单位牌，获得等同于其基础战力的增益
+        public KikimoreWarrior(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            if (!(await Game.GetSelectMenuCards(PlayerIndex, Game.PlayersDeck[PlayerIndex]
+            .Where(x => x.Is(Group.Copper, CardType.Unit) && x.CardInfo().CardId != Card.CardInfo().CardId && x.CardPoint() <= (Card.CardPoint()))
+            .ToList())).TrySingle(out var target))
+            {
+                return 0;
+            }
+            await Card.Effect.Consume(target, x => x.Status.Strength);
+            return 0;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/KikimoreWorker.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/KikimoreWorker.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70022")]//齐齐摩工兵
+    public class KikimoreWorker : CardEffect
+    {
+        //选择1个"类虫生物"单位，使其在手牌、牌组或己方半场所有同名牌获得2点增益。
+        public KikimoreWorker(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            var target = (await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.MyRow)).SingleOrDefault();
+            var cards = Game.GetPlaceCards(PlayerIndex).Concat(Game.PlayersHandCard[PlayerIndex]).Concat(Game.PlayersDeck[PlayerIndex]).FilterCards(filter: x => x.Status.CardId == target.Status.CardId).ToList();
+            if (cards.Count() == 0)
+            {
+                return 0;
+            }
+            foreach (var card in cards)
+            {
+                await card.Effect.Boost(2, Card);
+            }
+            return 0;
+        }
+    }
+}
+

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Sliver/FiggisMerluzzo.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Sliver/FiggisMerluzzo.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70020")]//菲吉斯·梅鲁佐
+    public class FiggisMerluzzo : CardEffect
+    {//召唤“卓尔坦·矮人战士”和“穆罗·布鲁伊斯”，并将自身战力应用于这两个单位。
+        public FiggisMerluzzo(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            if (true)
+            {
+
+            }
+            var myDeck = Game.GetPlaceCards(PlayerIndex).Concat(Game.PlayersDeck[PlayerIndex]).ToList();
+            var MunroBruyss = myDeck.Where(x => x.Status.CardId == CardId.MunroBruys).ToList();
+            var ZoltanWarriors = myDeck.Where(x => x.Status.CardId == CardId.ZoltanWarrior).ToList();
+            var targetcard = myDeck.Where(x => x.Status.CardId == CardId.MunroBruys || x.Status.CardId == CardId.ZoltanWarrior).ToList();
+            var point = Card.CardPoint()-Card.Status.Strength;
+            foreach (var MunroBruys in MunroBruyss)
+            {
+                await MunroBruys.Effect.Summon(Card.GetLocation(), Card);
+            }
+            foreach (var ZoltanWarrior in ZoltanWarriors)
+            {
+                await ZoltanWarrior.Effect.Summon(Card.GetLocation(), Card);
+            }
+            foreach(var Cards in targetcard)
+            {
+                await Cards.Effect.Boost(point, Card);
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Sliver/MunroBruys.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Sliver/MunroBruys.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70021")]//穆罗·布鲁伊斯
+    public class MunroBruys : CardEffect
+    {//召唤“卓尔坦·矮人战士”和“菲吉斯·梅鲁佐”，并使其获得等同于自身增益点数的增益
+        public MunroBruys(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            var myDeck = Game.GetPlaceCards(PlayerIndex).Concat(Game.PlayersDeck[PlayerIndex]).ToList();
+            var FiggisMerluzzos = myDeck.Where(x => x.Status.CardId == CardId.FiggisMerluzzo).ToList();
+            var ZoltanWarriors = myDeck.Where(x => x.Status.CardId == CardId.ZoltanWarrior).ToList();
+            var targetcard = myDeck.Where(x => x.Status.CardId == CardId.FiggisMerluzzo || x.Status.CardId == CardId.ZoltanWarrior).ToList();
+            var point = Card.CardPoint()-Card.Status.Strength;
+            foreach (var FiggisMerluzzo in FiggisMerluzzos)
+            {
+                await FiggisMerluzzo.Effect.Summon(Card.GetLocation() + 1, Card);
+            }
+            foreach (var ZoltanWarrior in ZoltanWarriors)
+            {
+                await ZoltanWarrior.Effect.Summon(Card.GetLocation() + 1, Card);
+            }
+            foreach(var Cards in targetcard)
+            {
+                await Cards.Effect.Boost(point, Card);
+            }
+            return 0;
+        }
+    }
+}
+
+
+
+
+
+
+
+

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Sliver/ZoltanWarrior.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Sliver/ZoltanWarrior.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70019")]//卓尔坦·矮人战士
+    public class ZoltanWarrior : CardEffect
+    {//召唤“菲吉斯·梅鲁佐”和“穆罗·布鲁伊斯”，并将自身战力应用于这两个单位。
+        public ZoltanWarrior(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            var myDeck = Game.GetPlaceCards(PlayerIndex).Concat(Game.PlayersDeck[PlayerIndex]).ToList();
+            var FiggisMerluzzos = myDeck.Where(x => x.Status.CardId == CardId.FiggisMerluzzo).ToList();
+            var MunroBruyss = myDeck.Where(x => x.Status.CardId == CardId.MunroBruys).ToList();
+            var targetcard = myDeck.Where(x => x.Status.CardId == CardId.MunroBruys || x.Status.CardId == CardId.FiggisMerluzzo).ToList();
+            var point = Card.CardPoint()-Card.Status.Strength;
+            
+            foreach (var FiggisMerluzzo in FiggisMerluzzos)
+            {
+                await FiggisMerluzzo.Effect.Summon(Card.GetLocation()+ 1, Card);
+            }
+            foreach (var MunroBruys in MunroBruyss)
+            {
+                await MunroBruys.Effect.Summon(Card.GetLocation(), Card);
+            }
+            foreach(var Cards in targetcard)
+            {
+                await Cards.Effect.Boost(point, Card);
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/Kayran.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/Kayran.cs
@@ -10,7 +10,7 @@ namespace Cynthia.Card
         public Kayran(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-            var targetCards = await Game.GetSelectPlaceCards(Card, filter: x => x.CardPoint() <= 7, selectMode: SelectModeType.EnemyRow);
+            var targetCards = await Game.GetSelectPlaceCards(Card, filter: x => x.CardPoint() <= 7, selectMode: SelectModeType.AllRow);
 
             if (!targetCards.TrySingle(out var target))
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/CardId.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/CardId.cs
@@ -532,5 +532,10 @@ namespace Cynthia.Card
         public const string ToussaintKnightErrant = "70012";
         public const string CorruptedFlaminca = "70013";
         public const string LandOfAThousandFables = "70014";
+        public const string ZoltanWarrior = "70019";
+        public const string FiggisMerluzzo = "70020";
+        public const string MunroBruys = "70021";
+        public const string KikimoreWorker = "70022";
+        public const string KikimoreWarrior = "70023";
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -10921,6 +10921,106 @@ namespace Cynthia.Card
                     CardArtsId = "d20470000",
                 }
             },
+            {
+                "70019",//卓尔坦·矮人战士
+                new GwentCard()
+                {
+                    CardId ="70019",
+                    Name = "卓尔坦·矮人战士",
+                    Strength = 4,
+                    Group = Group.Silver,
+                    Faction = Faction.ScoiaTael,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[]{ Categorie.Dwarf},
+                    Flavor = "",
+                    Info = "召唤“菲吉斯·梅鲁佐”和“穆罗·布鲁伊斯”，使二者获得等同于自身增益量的增益。",
+                    CardArtsId = "d19190000",
+                }
+            },
+            {
+                "70020",//菲吉斯·梅鲁佐
+                new GwentCard()
+                {
+                    CardId ="70020",
+                    Name = "菲吉斯·梅鲁佐",
+                    Strength = 3,
+                    Group = Group.Silver,
+                    Faction = Faction.ScoiaTael,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[]{ Categorie.Dwarf},
+                    Flavor = "",
+                    Info = "召唤“卓尔坦·矮人战士”和“穆罗·布鲁伊斯”，使二者获得等同于自身增益量的增益。",
+                    CardArtsId = "d19220000",
+                }
+            },
+            {
+                "70021",//穆罗·布鲁伊斯
+                new GwentCard()
+                {
+                    CardId ="70021",
+                    Name = "穆罗·布鲁伊斯",
+                    Strength = 3,
+                    Group = Group.Silver,
+                    Faction = Faction.ScoiaTael,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[]{ Categorie.Dwarf},
+                    Flavor = "",
+                    Info = "召唤“卓尔坦·矮人战士”和“菲吉斯·梅鲁佐”，使二者获得等同于自身增益量的增益。",
+                    CardArtsId = "d19210000",
+                }
+            },
+            {
+                "70022",//齐齐摩工兵
+                new GwentCard()
+                {
+                    CardId ="70022",
+                    Name = "齐齐摩工兵",
+                    Strength = 4,
+                    Group = Group.Copper,
+                    Faction = Faction.Monsters,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[]{ Categorie.Insectoid},
+                    Flavor = "",
+                    Info = "选择1个“类虫生物”单位，使其在手牌、牌组或己方半场所有同名牌获得2点增益。",
+                    CardArtsId = "d19140000",
+                }
+            },
+            {
+                "70023",//齐齐摩战士
+                new GwentCard()
+                {
+                    CardId ="70023",
+                    Name = "齐齐摩战士",
+                    Strength = 7,
+                    Group = Group.Copper,
+                    Faction = Faction.Monsters,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[]{ Categorie.Insectoid},
+                    Flavor = "",
+                    Info = "吞噬己方牌组中1个战力不大于自身的非同名铜色单位牌，获得等同于其基础战力的增益",
+                    CardArtsId = "d18430000",
+                }
+            },
 
         };
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/RowEffect/TorrentialRainStatus.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/RowEffect/TorrentialRainStatus.cs
@@ -11,12 +11,17 @@ namespace Cynthia.Card
         public async Task HandleEvent(AfterTurnStart @event)
         {
             if (@event.PlayerIndex != PlayerIndex) return;
-
-            var cards = AliveNotConceal.Mess(Game.RNG).Take(2);
+            var LowestCard = AliveNotConceal.WhereAllLowest();
+            var HighestCard = AliveNotConceal.WhereAllHighest();
+            if (AliveNotConceal.Count() == 0) return;
+            await LowestCard.Mess(Game.RNG).First().Effect.Damage(1, null, damageType: DamageType.TorrentialRain);
+            await HighestCard.Mess(Game.RNG).First().Effect.Damage(1, null, damageType: DamageType.TorrentialRain);
+            /*var cards = AliveNotConceal.Mess(Game.RNG).Take(2);
             foreach (var card in cards)
             {
                 await card.Effect.Damage(1, null, damageType: DamageType.TorrentialRain);
             }
+            */
         }
     }
 }


### PR DESCRIPTION
修改了巨章鱼怪只能吞对面的bug
将倾盆大雨修改为每回合对最强和最弱各打1
新添加了5张新卡牌，齐齐摩战士，齐齐摩工兵，卓尔坦·矮人战士，穆罗·布鲁伊斯，菲吉斯·梅鲁佐