### PR TITLE
添加诅咒北新卡：70024被诅咒的不朽者

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -135,6 +135,8 @@ namespace Cynthia.Card
             var isDead = Card.Status.CardRow.IsOnPlace();
             var deadposition = Game.GetCardLocation(Card);
 
+            await Game.SendEvent(new BeforeCardToCemetery(Card, deadposition, isRoundEnd));
+
             //进入墓地后撤销护盾
             Card.Status.IsShield = false;
 

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Copper/CursedImmortals.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Copper/CursedImmortals.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+using System;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70024")]//被诅咒的不朽者
+    public class CursedImmortals : CardEffect, IHandlesEvent<AfterCardDeath>, IHandlesEvent<BeforeCardToCemetery>
+    {//相邻诅咒单位被摧毁时，在同排最右侧生成一张“鬼灵”，然后削弱自身3点。
+
+        public CursedImmortals(GameCard card) : base(card) { }
+
+        private const int weakenPoint = 3;
+
+        private CardLocation myLoc;
+
+        public async Task HandleEvent(BeforeCardToCemetery @event)
+        {
+            // 因为在AfterCardDeath时，本卡的位置会移动，所以需要在之前的时点先存起来
+            myLoc = Card.GetLocation();
+            await Task.CompletedTask;
+        }
+
+        public async Task HandleEvent(AfterCardDeath @event)
+        {
+
+            if (Card.Status.CardRow.IsOnPlace())
+            {
+                var neighborCards = Card.GetRangeCard(1).ToList();
+                CardLocation deathLoc = @event.DeathLocation;
+
+                // if分开来写可读性更高
+                // 如果相邻
+                if (deathLoc.RowPosition == myLoc.RowPosition && Math.Abs(deathLoc.CardIndex - myLoc.CardIndex) <= 1)
+                {
+                    // 如果是诅咒
+                    if (@event.Target.HasAnyCategorie(Categorie.Cursed))
+                    {
+                        // 如果没有满
+                        if (Game.RowToList(PlayerIndex, deathLoc.RowPosition).Count < Game.RowMaxCount)
+                        {
+                            await Game.CreateCardAtEnd(CardId.Specter, PlayerIndex, deathLoc.RowPosition);
+                            await Card.Effect.Weaken(weakenPoint, Card);
+                        }
+                    }
+                }
+            }
+            return;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GameEvent/BeforeCardToCemetery.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GameEvent/BeforeCardToCemetery.cs
@@ -1,0 +1,18 @@
+namespace Cynthia.Card
+{
+    //卡牌进入墓地前
+    public class BeforeCardToCemetery : Event
+    {
+        public GameCard Target { get; set; }
+
+        public CardLocation DeathLocation { get; set; }
+
+        public bool isRoundEnd { get; set; }
+        public BeforeCardToCemetery(GameCard target, CardLocation deathLocation, bool IsRoundEnd=false)
+        {
+            Target = target;
+            DeathLocation = deathLocation;
+            isRoundEnd = IsRoundEnd;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/CardId.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/CardId.cs
@@ -532,5 +532,6 @@ namespace Cynthia.Card
         public const string ToussaintKnightErrant = "70012";
         public const string CorruptedFlaminca = "70013";
         public const string LandOfAThousandFables = "70014";
+        public const string CursedImmortals = "70024";
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -10921,6 +10921,26 @@ namespace Cynthia.Card
                     CardArtsId = "d20470000",
                 }
             },
+            {
+                "70024",//被诅咒的不朽者
+                new GwentCard()
+                {
+                    CardId = "70024",
+                    Name = "被诅咒的不朽者",
+                    Strength = 10,
+                    Group = Group.Copper,
+                    Faction = Faction.NorthernRealms,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[] { Categorie.Cursed,Categorie.Aedirn},
+                    Flavor = "",
+                    Info = "相邻诅咒单位被摧毁时，在同排最右侧生成一张“鬼灵”，然后削弱自身3点。",
+                    CardArtsId = "d20010000",
+                }
+            },
 
         };
     }


### PR DESCRIPTION
70024.【铜卡】被诅咒的不朽者 CursedImmortals
北方 单位卡 诅咒生物 亚甸 10战力
效果：相邻诅咒单位被摧毁时，在同排最右侧生成一张“鬼灵”，然后削弱自身3点。（鬼灵：5战力白板）