### PR TITLE
修复血红男爵和被诅咒的不朽者在佚亡单位被摧毁时不会触发特效的bug

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Copper/CursedImmortals.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Copper/CursedImmortals.cs
@@ -6,29 +6,21 @@ using System;
 namespace Cynthia.Card
 {
     [CardEffectId("70024")]//被诅咒的不朽者
-    public class CursedImmortals : CardEffect, IHandlesEvent<AfterCardDeath>, IHandlesEvent<BeforeCardToCemetery>
+    public class CursedImmortals : CardEffect, IHandlesEvent<BeforeCardToCemetery>
     {//相邻诅咒单位被摧毁时，在同排最右侧生成一张“鬼灵”，然后削弱自身3点。
 
         public CursedImmortals(GameCard card) : base(card) { }
 
         private const int weakenPoint = 3;
-
-        private CardLocation myLoc;
-
+        
         public async Task HandleEvent(BeforeCardToCemetery @event)
         {
-            // 因为在AfterCardDeath时，本卡的位置会移动，所以需要在之前的时点先存起来
-            myLoc = Card.GetLocation();
-            await Task.CompletedTask;
-        }
-
-        public async Task HandleEvent(AfterCardDeath @event)
-        {
-
-            if (Card.Status.CardRow.IsOnPlace())
+            // 因为在AfterCardDeath时，本卡的位置会移动，所以选择在BeforeCardToCemetery的时点触发
+            if (Card.Status.CardRow.IsOnPlace() && !@event.isRoundEnd)
             {
-                var neighborCards = Card.GetRangeCard(1).ToList();
+                CardLocation myLoc = Card.GetLocation();
                 CardLocation deathLoc = @event.DeathLocation;
+                var neighborCards = Card.GetRangeCard(1).ToList();
 
                 // if分开来写可读性更高
                 // 如果相邻

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Gold/BloodyBaron.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Gold/BloodyBaron.cs
@@ -5,12 +5,13 @@ using Alsein.Extensions;
 namespace Cynthia.Card
 {
     [CardEffectId("42002")]//血红男爵
-    public class BloodyBaron : CardEffect, IHandlesEvent<AfterCardDeath>
+    public class BloodyBaron : CardEffect, IHandlesEvent<BeforeCardToCemetery>
     {//若位于手牌、牌组或己方半场：有敌军单位被摧毁时获得1点增益。
         public BloodyBaron(GameCard card) : base(card) { }
-        public async Task HandleEvent(AfterCardDeath @event)
+        public async Task HandleEvent(BeforeCardToCemetery @event)
         {
-            if (@event.Target.PlayerIndex != Card.PlayerIndex && (Card.Status.CardRow.IsOnPlace() || Card.Status.CardRow.IsInDeck() || Card.Status.CardRow.IsInHand()))
+            if (!@event.isRoundEnd && @event.Target.PlayerIndex != Card.PlayerIndex
+                && (Card.Status.CardRow.IsOnPlace() || Card.Status.CardRow.IsInDeck() || Card.Status.CardRow.IsInHand()))
             {
                 await Card.Effect.Boost(1, Card);
             }


### PR DESCRIPTION
把触发时点从AfterCardDeath改为了BeforeCardToCemetery