### PR TITLE
修复齐齐摩工兵在场上没有"类虫生物"单位时打出时会卡死的bug

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/KikimoreWorker.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/KikimoreWorker.cs
@@ -12,6 +12,10 @@ namespace Cynthia.Card
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             var target = (await Game.GetSelectPlaceCards(Card, filter: (x => x.HasAnyCategorie(Categorie.Insectoid)), selectMode: SelectModeType.MyRow)).SingleOrDefault();
+            if (target == default)
+            {
+                return 0;
+            }
             var cards = Game.GetPlaceCards(PlayerIndex).Concat(Game.PlayersHandCard[PlayerIndex]).Concat(Game.PlayersDeck[PlayerIndex]).FilterCards(filter: x => x.Status.CardId == target.Status.CardId).ToList();
             if (cards.Count() == 0)
             {


### PR DESCRIPTION
修复齐齐摩工兵在场上没有"类虫生物"单位时打出时会卡死的bug