### PR TITLE
添加了Diy网盘地址

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Pages/Download.razor
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Pages/Download.razor
@@ -1,0 +1,49 @@
+@page "/download"
+@using Cynthia.Card.Server
+
+<style>
+.gwent-download{
+    margin: 10px 0px;
+}
+
+.gwent-download-div{
+    padding: 10px 0px;
+    margin: 10px 0px;
+}
+
+.gwent-download-button, .gwent-download-button:visited{
+    background-color: beige;
+    border-radius:15px;
+    padding: 10px;
+    height: 50px;
+    border: 1px solid black;
+}
+</style>
+
+<h1>下载地址</h1>
+<div class="gwent-download">
+<div class="gwent-download-div">
+<a href="https://share.weiyun.com/W8Pp4xRC" target="_blank" rel="noopener noreferrer">
+    <button class="gwent-download-button">DIY服-Windows下载</button>
+</a>
+</div>
+
+<div class="gwent-download-div">
+<a href="https://www.jianguoyun.com/p/DSwilY0Q-K-7CBi415sD" target="_blank" rel="noopener noreferrer">
+    <button class="gwent-download-button">DIY服-Android下载</button>
+</a>
+</div>
+
+<div class="gwent-download-div">
+<a href="https://www.jianguoyun.com/p/DRaHzxgQ-K-7CBi315sD" target="_blank" rel="noopener noreferrer">
+    <button class="gwent-download-button">DIY服-Mac下载</button>
+</a>
+</div>
+
+<div class="gwent-download-div">
+<a href="https://www.jianguoyun.com/p/DTpZeMcQ-K-7CBic15sD" target="_blank" rel="noopener noreferrer">
+    <button class="gwent-download-button">DIY服-Windows-语音抢先版下载</button>
+</a>
+</div>
+</div>
+<p>这里使用网盘地址，以节省服务器流量</p>

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Pages/Download.razor
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Pages/Download.razor
@@ -11,7 +11,7 @@
     margin: 10px 0px;
 }
 
-.gwent-download-button, .gwent-download-button:visited{
+.gwent-download-button{
     background-color: beige;
     border-radius:15px;
     padding: 10px;
@@ -22,28 +22,29 @@
 
 <h1>下载地址</h1>
 <div class="gwent-download">
-<div class="gwent-download-div">
-<a href="https://share.weiyun.com/W8Pp4xRC" target="_blank" rel="noopener noreferrer">
-    <button class="gwent-download-button">DIY服-Windows下载</button>
-</a>
+  <div class="gwent-download-div">
+    <a href="https://share.weiyun.com/W8Pp4xRC" target="_blank" rel="noopener noreferrer">
+      <button class="gwent-download-button">DIY服-Windows下载</button>
+    </a>
+  </div>
+
+  <div class="gwent-download-div">
+    <a href="https://www.jianguoyun.com/p/DSwilY0Q-K-7CBi415sD" target="_blank" rel="noopener noreferrer">
+      <button class="gwent-download-button">DIY服-Android下载</button>
+    </a>
+  </div>
+
+  <div class="gwent-download-div">
+    <a href="https://www.jianguoyun.com/p/DRaHzxgQ-K-7CBi315sD" target="_blank" rel="noopener noreferrer">
+      <button class="gwent-download-button">DIY服-Mac下载</button>
+    </a>
+  </div>
+
+  <div class="gwent-download-div">
+    <a href="https://www.jianguoyun.com/p/DTpZeMcQ-K-7CBic15sD" target="_blank" rel="noopener noreferrer">
+      <button class="gwent-download-button">DIY服-Windows-语音抢先版下载</button>
+    </a>
+  </div>
 </div>
 
-<div class="gwent-download-div">
-<a href="https://www.jianguoyun.com/p/DSwilY0Q-K-7CBi415sD" target="_blank" rel="noopener noreferrer">
-    <button class="gwent-download-button">DIY服-Android下载</button>
-</a>
-</div>
-
-<div class="gwent-download-div">
-<a href="https://www.jianguoyun.com/p/DRaHzxgQ-K-7CBi315sD" target="_blank" rel="noopener noreferrer">
-    <button class="gwent-download-button">DIY服-Mac下载</button>
-</a>
-</div>
-
-<div class="gwent-download-div">
-<a href="https://www.jianguoyun.com/p/DTpZeMcQ-K-7CBic15sD" target="_blank" rel="noopener noreferrer">
-    <button class="gwent-download-button">DIY服-Windows-语音抢先版下载</button>
-</a>
-</div>
-</div>
 <p>这里使用网盘地址，以节省服务器流量</p>

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Shared/NavMenu.razor
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Shared/NavMenu.razor
@@ -32,6 +32,11 @@
                 <span class="oi oi-plus" aria-hidden="true"></span> 投食名单
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="download">
+                <span class="oi oi-plus" aria-hidden="true"></span> 下载地址
+            </NavLink>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
在网站中增加了下载地址界面。

windows使用了腾讯微云：https://share.weiyun.com/W8Pp4xRC
android使用了坚果云：https://www.jianguoyun.com/p/DSwilY0Q-K-7CBi415sD
mac使用了坚果云：https://www.jianguoyun.com/p/DRaHzxgQ-K-7CBi315sD
windows语音抢先版使用了坚果云：https://www.jianguoyun.com/p/DTpZeMcQ-K-7CBic15sD
以上都是永久分享地址。

实际测试情况来看，坚果云的上传和下载都不限速，但网盘容量只有1G。腾讯微云、城通网盘、115网盘、蓝奏云等都有限速，微博微盘甚至要开会员才能上传文件。

其实可以直接服务器提供下载？不知道带宽压力会如何？