### PR TITLE
 平衡调整，仅数值修改部分

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/WildHuntWarrior.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/WildHuntWarrior.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("24016")]//狂猎战士
     public class WildHuntWarrior : CardEffect
-    {//对1个敌军单位造成3点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。
+    {//对1个敌军单位造成4点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。
         public WildHuntWarrior(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -16,7 +16,7 @@ namespace Cynthia.Card
                 return 0;
             }
             var isBoost = Game.GameRowEffect[target.PlayerIndex][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost;
-            await target.Effect.Damage(3, Card);
+            await target.Effect.Damage(4, Card);
             isBoost = isBoost || target.IsDead;
             if (isBoost)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Copper/DimeritiumShackles.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Copper/DimeritiumShackles.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("14007")]//阻魔金镣铐
     public class DimeritiumShackles : CardEffect
-    {//改变1个单位的锁定状态。若为敌军单位，则对它造成4点伤害。
+    {//改变1个单位的锁定状态。若为敌军单位，则对它造成5点伤害。
         public DimeritiumShackles(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
@@ -14,7 +14,7 @@ namespace Cynthia.Card
             if (result.Count <= 0) return 0;
             await result.Single().Effect.Lock(Card);
             if (result.Single().PlayerIndex != Card.PlayerIndex)
-                await result.Single().Effect.Damage(4, Card);
+                await result.Single().Effect.Damage(5, Card);
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Silver/CommanderSHorn.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Silver/CommanderSHorn.cs
@@ -6,13 +6,13 @@ namespace Cynthia.Card
 {
 	[CardEffectId("13027")]//指挥号角
 	public class CommanderSHorn : CardEffect
-	{//使5个相邻单位获得3点增益。
+	{//使7个相邻单位获得3点增益。
 		public CommanderSHorn(GameCard card) : base(card){}
 		public override async Task<int> CardUseEffect()
 		{
-			var result = await Game.GetSelectPlaceCards(Card,range:2);
+			var result = await Game.GetSelectPlaceCards(Card,range:3);
 			if(result.Count<=0) return 0;
-			foreach(var card in result.Single().GetRangeCard(2).ToList())
+			foreach(var card in result.Single().GetRangeCard(3).ToList())
 			{
 				if(card.Status.CardRow.IsOnPlace())
 					await card.Effect.Boost(3,Card);

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Gold/Assassination.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Gold/Assassination.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("32015")]//暗算
     public class Assassination : CardEffect
-    {//对1个敌军单位造成8点伤害，再对1个敌军单位造成8点伤害。
+    {//对1个敌军单位造成9点伤害，再对1个敌军单位造成9点伤害。
         public Assassination(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
@@ -14,7 +14,7 @@ namespace Cynthia.Card
             {
                 var result = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.EnemyRow);
                 if (result.Count <= 0) continue;
-                await result.Single().Effect.Damage(8, Card);
+                await result.Single().Effect.Damage(9, Card);
             }
             return 0;
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/FoltestSPride.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/FoltestSPride.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("43007")]//弗尔泰斯特之傲
     public class FoltestSPride : CardEffect
-    {//对1个敌军单位造成2点伤害，并将其上移一排。 驱动：再次触发此能力。
+    {//对1个敌军单位造成3点伤害，并将其上移一排。 驱动：再次触发此能力。
         public FoltestSPride(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -24,7 +24,7 @@ namespace Cynthia.Card
                     {
                         await target.Effect.Move(new CardLocation(tagetRow, 0), Card);
                     }
-                    await target.Effect.Damage(2, Card);
+                    await target.Effect.Damage(3, Card);
                 }
             }
             return 0;

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/VandergriftSBlade.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/VandergriftSBlade.cs
@@ -6,12 +6,12 @@ namespace Cynthia.Card
 {
     [CardEffectId("43021")]//范德格里夫特之剑
     public class VandergriftSBlade : CardEffect
-    {//择一：摧毁1个铜色/银色“诅咒单位”敌军单位；或造成9点伤害，放逐所摧毁的单位。
+    {//择一：摧毁1个铜色/银色“诅咒生物”敌军单位；或造成10点伤害，放逐所摧毁的单位。
         public VandergriftSBlade(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
             //卡牌描述来自https://www.bilibili.com/video/av17561142?from=search&seid=5862653946081547514 48：56
-            var switchCard = await Card.GetMenuSwitch(("一刀两断", "摧毁1个铜色/银色“诅咒单位”敌军单位。"), ("凶暴重击", "造成9点伤害，放逐所摧毁的单位"));
+            var switchCard = await Card.GetMenuSwitch(("一刀两断", "摧毁1个铜色/银色“诅咒单位”敌军单位。"), ("凶暴重击", "造成10点伤害，放逐所摧毁的单位"));
             if (switchCard == 0)
             {
                 var target = await Game.GetSelectPlaceCards(Card, 1, false,
@@ -31,7 +31,7 @@ namespace Cynthia.Card
                 {
                     return 0;
                 }
-                await target.Effect.Damage(9, Card);
+                await target.Effect.Damage(10, Card);
                 //如果目标没死，结束
                 if (!target.IsDead)
                 {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/TuirseachSkirmisher.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/TuirseachSkirmisher.cs
@@ -16,7 +16,7 @@ namespace Cynthia.Card
                 return;
             }
 
-            await Strengthen(3, Card);
+            await Strengthen(4, Card);
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Silver/HolgerBlackhand.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Silver/HolgerBlackhand.cs
@@ -7,7 +7,7 @@ namespace Cynthia.Card
     [CardEffectId("63011")]//“黑手”霍格
     public class HolgerBlackhand : CardEffect
     {
-        //造成6点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。
+        //造成7点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。
         public HolgerBlackhand(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -21,7 +21,7 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            await target.Effect.Damage(6, Card);
+            await target.Effect.Damage(7, Card);
             //如果目标没死，结束
             if (!target.IsDead)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -1600,7 +1600,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Tactic,Categorie.Special},
                     Flavor = "士气加一分，听力减三分。",
-                    Info = "使5个相邻单位获得3点增益。",
+                    Info = "使7个相邻单位获得3点增益。",
                     CardArtsId = "11320700",
                 }
             },
@@ -3904,7 +3904,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.WildHunt,Categorie.Soldier},
                     Flavor = "白霜将至。",
-                    Info = "对1个敌军单位造成3点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。",
+                    Info = "对1个敌军单位造成4点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。",
                     CardArtsId = "13230900",
                 }
             },
@@ -4911,7 +4911,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Tactic,Categorie.Special},
                     Flavor = "“请你出手要多少钱？” “看情况喽。比如说目标是你，大改100奥伦币左右。”",
-                    Info = "对1个敌军单位造成8点伤害，再对1个敌军单位造成8点伤害。",
+                    Info = "对1个敌军单位造成9点伤害，再对1个敌军单位造成9点伤害。",
                     CardArtsId = "16310100",
                 }
             },
@@ -6558,7 +6558,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Machine},
                     Flavor = "正如弗尔泰斯特国王常说的那样，尺寸并不重要，关键要好用。",
-                    Info = "对1个敌军单位造成2点伤害，并将其上移一排。 驱动：再次触发此能力。",
+                    Info = "对1个敌军单位造成3点伤害，并将其上移一排。 驱动：再次触发此能力。",
                     CardArtsId = "20149400",
                 }
             },
@@ -6839,7 +6839,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Special,Categorie.Item},
                     Flavor = "在阿德卡莱的一次骑士比武中，赛尔奇克打断了范德格里夫特的长剑。于是，愤怒的范德格里夫特下令铸造一把新的兵刃，还在上面附了强大的符文石。",
-                    Info = "择一：摧毁1个铜色/银色“诅咒单位”敌军单位；或造成9点伤害，放逐所摧毁的单位。",
+                    Info = "择一：摧毁1个铜色/银色“诅咒单位”敌军单位；或造成10点伤害，放逐所摧毁的单位。",
                     CardArtsId = "20163300",
                 }
             },
@@ -9495,7 +9495,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.ClanDimun,Categorie.Officer},
                     Flavor = "敬尼弗迦德皇帝，祝他不得善终！",
-                    Info = "造成6点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。",
+                    Info = "造成7点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。",
                     CardArtsId = "15220700",
                 }
             },
@@ -9915,7 +9915,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Soldier,Categorie.ClanTuirseach},
                     Flavor = "记好了：我们对朋友掏心窝，对敌人挥斧子。",
-                    Info = "被复活后获得3点强化。",
+                    Info = "被复活后获得4点强化。",
                     CardArtsId = "15231300",
                 }
             },

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -6839,7 +6839,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Special,Categorie.Item},
                     Flavor = "在阿德卡莱的一次骑士比武中，赛尔奇克打断了范德格里夫特的长剑。于是，愤怒的范德格里夫特下令铸造一把新的兵刃，还在上面附了强大的符文石。",
-                    Info = "择一：摧毁1个铜色/银色“诅咒单位”敌军单位；或造成10点伤害，放逐所摧毁的单位。",
+                    Info = "择一：摧毁1个铜色/银色“诅咒生物”敌军单位；或造成10点伤害，放逐所摧毁的单位。",
                     CardArtsId = "20163300",
                 }
             },


### PR DESCRIPTION
指挥号角 平票 按原计划3X7实装

阻魔金镣铐
伤害4=>5

暗算
9+9
对1个敌军单位造成8点伤害，再对1个敌军单位造成9点伤害。",

黑手霍格
打6=> 7

图尔塞克好斗分子
强化3=>4

范德格里夫特之剑
文字修改“诅咒单位”=>“诅咒生物”
摧毁=>放逐，打9=>10

狂猎战士
+1伤害

福尔泰斯特之傲
2->3