### PR TITLE
平衡调整，有效果重做的：

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/IceGiant.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/IceGiant.cs
@@ -4,18 +4,25 @@ using Alsein.Extensions;
 
 namespace Cynthia.Card
 {
-	[CardEffectId("24021")]//寒冰巨人
-	public class IceGiant : CardEffect
-	{//若场上任意位置有“刺骨冰霜”，则获得6点增益。
-		public IceGiant(GameCard card) : base(card){}
-		public override async Task<int> CardPlayEffect(bool isSpying,bool isReveal)
-		{
-            var flag = Game.GameRowEffect.SelectMany(x => x.Select(x => x.RowStatus)).Any(x => x == RowStatus.BitingFrost);
-            if(flag)
+    [CardEffectId("24021")]//寒冰巨人
+    public class IceGiant : CardEffect, IHandlesEvent<AfterWeatherApply>
+    {//场上每有一个“刺骨冰霜“灾厄效果，便获得3点增益。每有一个“刺骨冰霜“灾厄效果出现在场上，便获得3点增益。
+        public IceGiant(GameCard card) : base(card) { }
+        private const int increment = 3;
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            var count = Game.GameRowEffect.SelectMany(x => x.Select(x => x.RowStatus)).Where(x => x == RowStatus.BitingFrost).Count();
+            await Boost(count * increment, Card);
+            return 0;
+        }
+		public async Task HandleEvent(AfterWeatherApply @event)
+        {
+            //如果在场上且特效是霜
+            if (Card.Status.CardRow.IsOnPlace() && @event.Type == RowStatus.BitingFrost)
             {
-                await Boost(6, Card);
+                await Boost(increment, Card);
             }
-			return 0;
-		}
-	}
+            return;
+        }
+    }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/Imlerith.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/Imlerith.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("22005")]//伊勒瑞斯
     public class Imlerith : CardEffect
-    {//对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则伤害变为8点。
+    {//对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则将其摧毁。
         public Imlerith(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -14,8 +14,15 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            int point = Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost ? 8 : 4;
-            await target.Effect.Damage(point, Card);
+            //int point = Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost ? 8 : 4;
+            if(Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost)
+            {
+                await target.Effect.ToCemetery(CardBreakEffectType.Scorch);
+            }
+            else
+            {
+                await target.Effect.Damage(4, Card);
+            }
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/Ciri.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/Ciri.cs
@@ -6,11 +6,12 @@ namespace Cynthia.Card
 {
     [CardEffectId("12019")]//希里
     public class Ciri : CardEffect, IHandlesEvent<AfterRoundOver>
-    {//己方输掉小局时返回手牌。 2点护甲。
+    {//获得护盾。己方输掉小局时返回手牌。 2点护甲。
         public Ciri(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             await Card.Effect.Armor(2, Card);
+            Card.Status.IsShield = true;
             return 0;
         }
 

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Silver/Cadaverine.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Silver/Cadaverine.cs
@@ -7,7 +7,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("33021")]//吊死鬼之毒
     public class Cadaverine : CardEffect
-    {//择一：对1个敌军单位以及所有与它同类型的单位造成2点伤害；或摧毁1个铜色/银色“中立”单位。
+    {//择一：对1个敌军单位以及所有与它同类型的单位造成3点伤害；或摧毁1个铜色/银色“中立”单位。
         public Cadaverine(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
@@ -29,7 +29,7 @@ namespace Cynthia.Card
                 await Game.Debug($"筛选出了{targetCards.Count()}个");
                 foreach (var card in targetCards)
                 {
-                    await card.Effect.Damage(2, Card, BulletType.RedLight);
+                    await card.Effect.Damage(3, Card, BulletType.RedLight);
                 }
             }
             else if (switchCard == 1)

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Copper/Winch.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Copper/Winch.cs
@@ -10,11 +10,43 @@ namespace Cynthia.Card
         public Winch(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
-            var list = Game.GetPlaceCards(PlayerIndex).FilterCards(filter: x => x.HasAllCategorie(Categorie.Machine) && x.CardInfo().CardType == CardType.Unit);
-            foreach (var card in list)
+            //选择选项,设置每个选项的名字和效果
+            var switchCard = await Card.GetMenuSwitch
+            (
+                ("复活", "从己方墓场中打出 1 张铜色“机械”牌，并使其获得佚亡。"),
+                ("增益", "所有己方机械+3增益。")
+            );
+
+            if (switchCard == 0)
             {
-                await card.Effect.Boost(3, Card);
+                var list = Game.PlayersCemetery[PlayerIndex].Where(x => (x.Status.Group == Group.Copper) && x.CardInfo().CardType == CardType.Unit && x.HasAnyCategorie(Categorie.Machine)).ToList();
+                if (list.Count() == 0)
+                {
+                    return 0;
+                }
+                //让玩家选择一张卡
+                var result = await Game.GetSelectMenuCards
+                (Card.PlayerIndex, list.ToList(), 1, "选择复活一张牌");
+                //如果玩家一张卡都没选择,没有效果
+                if (result.Count() == 0)
+                {
+                    return 0;
+                }
+                var resurrectCard = result.First();
+                resurrectCard.Status.IsDoomed = true;
+                await resurrectCard.Effect.Resurrect(new CardLocation() { RowPosition = RowPosition.MyStay, CardIndex = 0 }, Card);
+                return 1;
             }
+            else if (switchCard == 1)
+            {
+                var list = Game.GetPlaceCards(PlayerIndex).FilterCards(filter: x => x.HasAllCategorie(Categorie.Machine) && x.CardInfo().CardType == CardType.Unit);
+                foreach (var card in list)
+                {
+                    await card.Effect.Boost(3, Card);
+                }
+                return 0;
+            }
+
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/HawkerHealer.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/HawkerHealer.cs
@@ -7,7 +7,7 @@ namespace Cynthia.Card
     [CardEffectId("54018")] //私枭治疗者
     public class HawkerHealer : CardEffect
     {
-        //使2个友军单位获得3点增益。
+        //使2个友军单位获得3点增益，随后将他们治愈。
         public HawkerHealer(GameCard card) : base(card)
         {
         }
@@ -19,8 +19,11 @@ namespace Cynthia.Card
             foreach (var card in cards)
             {
                 await card.Effect.Boost(boost,Card);
+                if (card.Status.HealthStatus < 0)
+                {
+                    await card.Effect.Heal(card);
+                }
             }
-
             return 0;
         }
 

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/Saesenthessis.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/Saesenthessis.cs
@@ -6,21 +6,21 @@ namespace Cynthia.Card
 {
     [CardEffectId("52002")]//萨琪亚萨司
     public class Saesenthessis : CardEffect
-    {//增益自身等同于友军“矮人”单位数量；造成等同于友军“精灵”单位数量的伤害。
+    {//增益自身等同于友军和手牌中“矮人”单位数量；造成等同于友军和手牌中“精灵”单位数量的伤害。
         public Saesenthessis(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             var listDwarf = Game.GetPlaceCards(Card.PlayerIndex).FilterCards(filter: x => x.HasAnyCategorie(Categorie.Dwarf)).ToList();
+            var handDwarf = Game.PlayersHandCard[PlayerIndex].FilterCards(filter: x => x.HasAnyCategorie(Categorie.Dwarf)).ToList();
 
-
-            int boostNum = listDwarf.Count();
+            int boostNum = listDwarf.Count() + handDwarf.Count();
 
             await Card.Effect.Boost(boostNum, Card);
 
             var listElf = Game.GetPlaceCards(Card.PlayerIndex).FilterCards(filter: x => x.HasAnyCategorie(Categorie.Elf)).ToList();
+            var handElf = Game.PlayersHandCard[PlayerIndex].FilterCards(filter: x => x.HasAnyCategorie(Categorie.Elf)).ToList();
 
-
-            int damageNum = listElf.Count();
+            int damageNum = listElf.Count() + handElf.Count();
 
             if (damageNum == 0)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Gold/Cerys.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Gold/Cerys.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("62007")]//凯瑞丝·奎特
     public class Cerys : CardEffect, IHandlesEvent<AfterCardResurrect>
-    {//位于墓场中时，在己方复活 4个单位后，复活单位。
+    {//位于墓场中时，在己方复活 4个单位后，复活单位，并获得1点强化。
         public Cerys(GameCard card) : base(card) { }
 
         public async Task HandleEvent(AfterCardResurrect @event)
@@ -20,6 +20,7 @@ namespace Cynthia.Card
                     await Card.Effect.Resurrect(new CardLocation() { RowPosition = Game.GetRandomCanPlayLocation(Card.PlayerIndex, true).RowPosition, CardIndex = int.MaxValue }, Card);
                     //重置计数器，复活到随机排最右侧
                     await Card.Effect.SetCountdown(value: 4);
+                    await Card.Effect.Strengthen(1, Card);
                 }
             }
             return;

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -531,7 +531,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Cintra,Categorie.Witcher},
                     Flavor = "去往何处，何时动身，我自己说了算。",
-                    Info = "己方输掉小局时返回手牌。 2点护甲。",
+                    Info = "获得护盾。己方输掉小局时返回手牌。 2点护甲。",
                     CardArtsId = "11210100",
                 }
             },
@@ -2960,7 +2960,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.WildHunt,Categorie.Officer},
                     Flavor = "叫他们有来无回！",
-                    Info = "对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则伤害变为8点。",
+                    Info = "对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则将其摧毁。",
                     CardArtsId = "13210200",
                 }
             },
@@ -4006,7 +4006,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Ogroid},
                     Flavor = "我这辈子只当过一次逃兵，就是碰上寒冰巨人那次——我一点也没觉得丢人。",
-                    Info = "若场上任意位置有“刺骨冰霜”，则获得6点增益。",
+                    Info = "场上每有一个“刺骨冰霜“灾厄效果，便获得3点增益。每有一个“刺骨冰霜“灾厄效果出现在场上，便获得3点增益。",
                     CardArtsId = "13221200",
                 }
             },
@@ -5332,7 +5332,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Alchemy,Categorie.Special,Categorie.Item},
                     Flavor = "我不会拿自己的性命去碰运气。我会拿上一把长剑，厚厚地涂上一层吊死鬼之毒。",
-                    Info = "择一：对1个敌军单位以及所有与它同类型的单位造成2点伤害；或摧毁1个铜色/银色“中立”单位。",
+                    Info = "择一：对1个敌军单位以及所有与它同类型的单位造成3点伤害；或摧毁1个铜色/银色“中立”单位。",
                     CardArtsId = "20154000",
                 }
             },
@@ -6598,7 +6598,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Soldier,Categorie.Kaedwen},
                     Flavor = "喝酒少了欧德林，就像划船没带桨。",
-                    Info = "回合开始时，移至随机排，并使同排所有友军单位获得1点增益。",
+                    Info = "回合开始时，移至随机排，并使同排所有友军单位获得1点增益。遗愿：使同排所有友军单位获得1点增益。",
                     CardArtsId = "12221300",
                 }
             },
@@ -7504,7 +7504,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Tactic,Categorie.Special},
                     Flavor = "就是一个绞盘。没什么可大惊小怪的。",
-                    Info = "使所有己方半场的“机械”单位获得3点增益。",
+                    Info = "绞盘：择一：从己方墓场中打出 1 张铜色“机械”牌，并使其获得佚亡。或所有己方机械+3增益。。",
                     CardArtsId = "20165900",
                 }
             },
@@ -7694,7 +7694,7 @@ namespace Cynthia.Card
                 {
                     CardId ="52002",
                     Name="萨琪亚萨司",
-                    Strength=10,
+                    Strength=9,
                     Group=Group.Gold,
                     Faction = Faction.ScoiaTael,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -7704,7 +7704,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Aedirn,Categorie.Draconid},
                     Flavor = "我继承了父亲的变身能力……好吧，尽管我只有一种变化形态。",
-                    Info = "增益自身等同于友军“矮人”单位数量；造成等同于友军“精灵”单位数量的伤害。",
+                    Info = "增益自身等同于友军和手牌中“矮人”单位数量；造成等同于友军和手牌中“精灵”单位数量的伤害。",
                     CardArtsId = "14210100",
                 }
             },
@@ -8711,7 +8711,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Elf,Categorie.Support},
                     Flavor = "帮你包扎，没问题——只要你有钱。",
-                    Info = "使2个友军单位获得3点增益。",
+                    Info = "使2个友军单位获得3点增益，随后将他们治愈。",
                     CardArtsId = "14230100",
                 }
             },
@@ -9153,7 +9153,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.ClanAnCraite,Categorie.Officer},
                     Flavor = "大家叫我小雀鹰，知道为什么吗？因为我专治你这种鼠辈。",
-                    Info = "位于墓场中时，在己方复活4个单位后，复活此单位。",
+                    Info = "位于墓场中时，在己方复活4个单位后，复活此单位，并获得1点强化。",
                     CardArtsId = "20017700",
                 }
             },


### PR DESCRIPTION
（修正吊死鬼的效果）
寒冰巨人
6战力 部署：场上每有一排霜，获得3增益。场上任何位置有霜打出时，获得3增益。

绞盘
择一：从己方墓场中打出 1 张铜色“机械”牌，并使其获得佚亡。或所有己方机械+3增益。

萨奇亚萨斯
10->9，伤害和增益计数方式:场上=>场上 + 手牌中

私枭治疗者
原效果 + 随后治愈该单位

凯瑞丝·奎特
+被复活后获得1点强化

欧德林
+遗愿：同排1点增益

老大锤
若位于冰霜之下摧毁

希里
+护盾