### PR TITLE
平衡改动：

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Silver/WarElephant.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Silver/WarElephant.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Alsein.Extensions;
+using System.Collections.Generic;
+
+namespace Cynthia.Card
+{
+    [CardEffectId("70033")]//杰洛特：亚登法印
+    public class WarElephant : CardEffect
+    {//摧毁己方单排所有单位的护甲，并造成扣除护甲值的伤害。
+        public WarElephant(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            var result = await Game.GetSelectRow(Card.PlayerIndex, Card, new List<RowPosition>() { RowPosition.MyRow1, RowPosition.MyRow2, RowPosition.MyRow3 });
+            var row = Game.RowToList(Card.PlayerIndex, result).IgnoreConcealAndDead();
+            int damagenum = 0;
+            foreach (var card in row)
+            {
+                if (card.Status.Armor > 0)
+                {
+                    damagenum = damagenum + card.Status.Armor;
+                    await card.Effect.Damage(card.Status.Armor, Card);
+                }
+            }
+            var result2 = await Game.GetSelectPlaceCards(Card);
+            if (result2.Count <= 0) return 0;
+            await result2.Single().Effect.Damage(damagenum, Card);
+            return 0;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/Archgriffin.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/Archgriffin.cs
@@ -12,6 +12,21 @@ namespace Cynthia.Card
 		{
             if (Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()].RowStatus.IsHazard())
                 await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()].SetStatus<NoneStatus>();
+            var enemylist = Game.PlayersCemetery[Game.AnotherPlayer(Card.PlayerIndex)].Where(x => x.CardInfo().CardType == CardType.Unit && x.Status.Group == Group.Copper).ToList();
+            //如果没有铜色单位，什么都不做
+            if (enemylist.Count() == 0)
+            {
+                return 0;
+            }
+            //选择一个铜色单位，如果不选，什么都不做
+            var MoveTarget = await Game.GetSelectMenuCards(Card.PlayerIndex, enemylist.ToList(), 1);
+            if (MoveTarget.Count() == 0)
+            {
+                return 0;
+            }
+            //移动到我方墓地
+            //不清楚refresh的含义
+            await Game.ShowCardMove(new CardLocation() { RowPosition = RowPosition.EnemyCemetery, CardIndex = 0 }, MoveTarget.Single());
             return 0;
 		}
 	}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/AleOfTheAncestors.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/AleOfTheAncestors.cs
@@ -5,9 +5,10 @@ using Alsein.Extensions;
 namespace Cynthia.Card
 {
     [CardEffectId("12009")]//先祖麦酒
-    public class AleOfTheAncestors : CardEffect
-    {//在所在排洒下“黄金酒沫”。
+    public class AleOfTheAncestors : CardEffect, IHandlesEvent<AfterCardHurt>, IHandlesEvent<AfterCardMove>
+    {//在所在排洒下“黄金酒沫”。被移动或伤害时重复此能力。
         public AleOfTheAncestors(GameCard card) : base(card) { }
+        
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             // await Game.ApplyWeather(PlayerIndex,Card.Status.CardRow,RowStatus.GoldenFroth);
@@ -15,5 +16,35 @@ namespace Cynthia.Card
                 .SetStatus<GoldenFrothStatus>();
             return 0;
         }
+        
+        public async Task HandleEvent(AfterCardHurt @event)
+        {
+            if (@event.Target != Card || !Card.Status.CardRow.IsOnPlace())
+            {
+                return;
+            }
+            await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()]
+               .SetStatus<GoldenFrothStatus>();
+            return;
+        }
+
+        public async Task HandleEvent(AfterCardMove @event)
+        {
+            if (@event.Target == Card)
+            {
+                await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()]
+               .SetStatus<GoldenFrothStatus>();
+            }
+        }
+
+        /*
+        public async Task HandleEvent(AfterTurnOver @event)
+        {
+            if (!(Card.Status.CardRow.IsOnPlace() && PlayerIndex == @event.PlayerIndex)) return;
+            await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()]
+                .SetStatus<GoldenFrothStatus>();
+            return;
+        }
+        */
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Copper/AlbaPikeman.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Copper/AlbaPikeman.cs
@@ -4,18 +4,41 @@ using Alsein.Extensions;
 
 namespace Cynthia.Card
 {
-    [CardEffectId("34024")]//阿尔巴师枪兵
-    public class AlbaPikeman : CardEffect
-    {//召唤所有同名牌。
+    [CardEffectId("34024")]//阿尔巴师枪兵  
+    public class AlbaPikeman : CardEffect, IHandlesEvent<AfterTurnStart>
+    {//回合开始时从卡组召唤1张同名牌，2点护甲。
         public AlbaPikeman(GameCard card) : base(card) { }
-        public override async Task<int> CardPlayEffect(bool isSpying,bool isReveal)
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-            var cards = Game.PlayersDeck[PlayerIndex].Where(x => x.Status.CardId == Card.Status.CardId).ToList();
-            foreach (var card in cards)
-            {
-                await card.Effect.Summon(Card.GetLocation() + 1, Card);
-            }
+            await Card.Effect.Armor(2, Card);
             return 0;
+        }
+
+        public override async Task CardDownEffect(bool isSpying, bool isReveal)
+        {
+            await Card.Effect.SetCountdown(1);
+            return;
+        }
+
+        public async Task HandleEvent(AfterTurnStart @event)
+        {
+            if (!(Card.Status.CardRow.IsOnPlace() && PlayerIndex == @event.PlayerIndex))
+                return;
+            if (Game.PlayersDeck[PlayerIndex].Any(t => t.Status.CardId == Card.Status.CardId))
+            {
+                if (!Game.PlayersDeck[PlayerIndex].Where(x => x.Status.CardId == Card.Status.CardId).TryMessOne(out var card, Game.RNG) || Card.Status.Countdown < 1)
+                {
+                    return;
+                }
+                await Card.Effect.SetCountdown(offset: -1);
+                await card.Effect.Summon(Card.GetLocation() + 1, Card);
+                await card.Effect.SetCountdown(1);
+                await card.Effect.Armor(2, Card);
+                //一定程度上是强行提供了特例护甲，“召唤”按道理不应当带护甲
+                //但蠢驴其中一个版本就是这样
+                //我本人也比较支持护甲是基本属性
+            }
+            return;
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Copper/DamnedSorceress.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Copper/DamnedSorceress.cs
@@ -6,11 +6,12 @@ namespace Cynthia.Card
 {
     [CardEffectId("44025")]//中邪的女术士
     public class DamnedSorceress : CardEffect
-    {//若同排有1个“诅咒生物”单位，则造成7点伤害。
+    {//若同排有“诅咒生物”单位，造成7点伤害。同排每有1个“诅咒生物”单位，伤害提高1点。
         public DamnedSorceress(GameCard card) : base(card) { }
         public override async Task CardDownEffect(bool isSpying, bool isReveal)
         {
             var list = Game.RowToList(PlayerIndex, Card.Status.CardRow).IgnoreConcealAndDead().Where(x => x.HasAnyCategorie(Categorie.Cursed) && x != Card);
+            /*
             if (list.Count() >= 1)
             {
                 var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.AllRow);
@@ -19,6 +20,15 @@ namespace Cynthia.Card
                     return;
                 }
                 await target.Effect.Damage(7, Card);
+            }*/
+            if (list.Count() >= 1)
+            {
+                var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.AllRow);
+                if (!selectList.TrySingle(out var target))
+                {
+                    return;
+                }
+                await target.Effect.Damage(7 + list.Count(), Card);
             }
             return;
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/XavierMoran.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/XavierMoran.cs
@@ -5,23 +5,51 @@ using Alsein.Extensions;
 namespace Cynthia.Card
 {
     [CardEffectId("52003")]//泽维尔·莫兰
-    public class XavierMoran : CardEffect
-    {//增益自身等同于最后打出的非同名“矮人”单位牌的初始战力。
+    public class XavierMoran : CardEffect, IHandlesEvent<AfterRoundOver>, IHandlesEvent<AfterUnitDown>
+    {//增益自身等同于本小局打出的“矮人”单位牌的最强基础战力。
         public XavierMoran(GameCard card) : base(card) { }
+        private int boostNum = 0;
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-
+            /*
             var cards = Game.HistoryList
                 .Where(x => (x.CardId.Status.CardId != Card.Status.CardId && x.CardId.CardInfo().Categories.Contains(Categorie.Dwarf)))
                             .ToList();
             if (cards.Count() <= 0) return 0;
 
             var lastDwarfCardId = cards.Last().CardId.Status.CardId;
-            var boostNum = GwentMap.CardMap[lastDwarfCardId].Strength;
+            boostNum = GwentMap.CardMap[lastDwarfCardId].Strength;
+            */
             await Card.Effect.Boost(boostNum, Card);
             return 0;
 
 
         }
+        public async Task HandleEvent(AfterUnitDown @event) //每下一个矮人打擂台
+        {
+            if (@event.Target == Card) return;
+            if (PlayerIndex == @event.Target.PlayerIndex && @event.Target.HasAllCategorie(Categorie.Dwarf))
+            {
+                if (boostNum < @event.Target.Status.Strength)
+                {
+                    await Task.Run(() => {
+
+                        boostNum = @event.Target.Status.Strength;
+
+                    });//异步运行,其实感觉不用 
+                }
+            }
+        }
+
+        public async Task HandleEvent(AfterRoundOver @event) //每小局结束清零
+        {
+            await Task.Run(() => {
+
+                boostNum = 0;
+
+            });//异步运行,其实感觉不用
+            
+        }
     }
+    
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DrummondShieldmaid.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DrummondShieldmaid.cs
@@ -6,16 +6,29 @@ namespace Cynthia.Card
 {
     [CardEffectId("64026")]//德拉蒙家族持盾女卫
     public class DrummondShieldmaid : CardEffect
-    {//召唤所有同名牌。
+    {//对一个敌军单位造成2点伤害，若目标已受伤，从卡组打出1张自身同名牌
         public DrummondShieldmaid(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-            var cards = Game.PlayersDeck[PlayerIndex].Where(x => x.Status.CardId == Card.Status.CardId).ToList();
-            foreach (var card in cards)
+            var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.AllRow);
+            if (!selectList.TrySingle(out var target))
             {
-                await card.Effect.Summon(Card.GetLocation() + 1, Card);
+                return 0;
             }
-            return 0;
+            if (target.Status.HealthStatus >= 0)
+            {
+                await target.Effect.Damage(2, Card);
+                return 0;
+            }
+
+            //如果目标没受伤，结束
+            await target.Effect.Damage(2, Card);
+            if (!Game.PlayersDeck[PlayerIndex].Where(x => x.Status.CardId == Card.Status.CardId).TryMessOne(out var card, Game.RNG))
+            {
+                return 0;
+            }
+            await card.MoveToCardStayFirst();
+            return 1;
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Derive/SpectralWhale.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Derive/SpectralWhale.cs
@@ -7,8 +7,8 @@ using System.Collections.Generic;
 namespace Cynthia.Card
 {
     [CardEffectId("65004")]//幽灵鲸
-    public class SpectralWhale : CardEffect, IHandlesEvent<AfterTurnOver>
-    {//回合结束时移至随机排，对同排所有其他单位造成1点伤害。 间谍。
+    public class SpectralWhale : CardEffect, IHandlesEvent<AfterTurnOver>, IHandlesEvent<AfterCardDeath>
+    {//回合结束时移至随机排，对同排所有其他单位造成1点伤害。遗愿：再次触发此能力。间谍。
         public SpectralWhale(GameCard card) : base(card) { }
         public async Task HandleEvent(AfterTurnOver @event)
         {
@@ -47,9 +47,24 @@ namespace Cynthia.Card
                 await card.Effect.Damage(1, Card);
             }
             return;
+        }
 
-
-
+        public async Task HandleEvent(AfterCardDeath @event)
+        {
+            if (@event.Target != Card)
+            {
+                return;
+            }
+            var damagelist = Game.RowToList(Card.PlayerIndex, @event.DeathLocation.RowPosition).IgnoreConcealAndDead().Where(x => x.GetLocation().RowPosition.IsOnPlace() && x != Card).ToList();
+            if (damagelist.Count() <= 1)
+            {
+                return;
+            }
+            foreach (var card in damagelist)
+            {
+                await card.Effect.Damage(1, Card);
+            }
+            return;
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Gold/Vabjorn.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Gold/Vabjorn.cs
@@ -17,10 +17,11 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            await target.Effect.Damage(2, Card);
+
             //如果目标没受伤，结束
             if (target.Status.HealthStatus >= 0)
             {
+                await target.Effect.Damage(2, Card);
                 return 0;
             }
             await target.Effect.ToCemetery(CardBreakEffectType.Scorch);

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 18);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 19);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 
@@ -316,7 +316,7 @@ namespace Cynthia.Card
                 {
                     CardId ="12009",
                     Name="先祖麦酒",
-                    Strength=10,
+                    Strength=9,
                     Group=Group.Gold,
                     Faction = Faction.Neutral,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -326,7 +326,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{},
                     Flavor = "富克斯家族的传奇创始人波罗斯因为酗酒丢了性命。当时他的金戒指掉进了一条小溪，他去捞的时候晕了过去。",
-                    Info = "在所在排洒下“黄金酒沫”。",
+                    Info = "在所在排洒下“黄金酒沫”。被移动或受到伤害时重复此能力。",
                     CardArtsId = "20024400",
                 }
             },
@@ -3651,7 +3651,7 @@ namespace Cynthia.Card
                 {
                     CardId ="24004",
                     Name="大狮鹫",
-                    Strength=10,
+                    Strength=9,
                     Group=Group.Copper,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -3661,7 +3661,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Beast},
                     Flavor = "大狮鹫也是狮鹫，只是更加凶悍。",
-                    Info = "移除所在排的灾厄。",
+                    Info = "移除所在排的灾厄。从对方墓场中1张铜色单位牌移至己方墓场。",
                     CardArtsId = "13230700",
                 }
             },
@@ -3996,7 +3996,7 @@ namespace Cynthia.Card
                 {
                     CardId ="24021",
                     Name="寒冰巨人",
-                    Strength=6,
+                    Strength=7,
                     Group=Group.Copper,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -4057,7 +4057,7 @@ namespace Cynthia.Card
                 {
                     CardId ="24024",
                     Name="女蛇妖",
-                    Strength=6,
+                    Strength=7,
                     Group=Group.Copper,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -5803,7 +5803,7 @@ namespace Cynthia.Card
                 {
                     CardId ="34024",
                     Name="阿尔巴师枪兵",
-                    Strength=3,
+                    Strength=5,
                     Group=Group.Copper,
                     Faction = Faction.Nilfgaard,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -5813,7 +5813,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Soldier},
                     Flavor = "宣誓效忠吾皇恩希尔·恩瑞斯……不然就受刑吧！",
-                    Info = "召唤所有同名牌。",
+                    Info = "回合开始时从卡组召唤1张同名牌。2点护甲。",
                     CardArtsId = "16231100",
                 }
             },
@@ -7343,7 +7343,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Mage,Categorie.Cursed},
                     Flavor = "萨宾娜的诅咒谁也不放过，就连其他的女术士也难以幸免。",
-                    Info = "若同排有1个“诅咒生物”单位，则造成7点伤害。",
+                    Info = "若同排有“诅咒生物”单位，造成7点伤害。同排每有1个“诅咒生物”单位，伤害提高1点。",
                     CardArtsId = "20163000",
                 }
             },
@@ -7694,7 +7694,7 @@ namespace Cynthia.Card
                 {
                     CardId ="52002",
                     Name="萨琪亚萨司",
-                    Strength=9,
+                    Strength=10,
                     Group=Group.Gold,
                     Faction = Faction.ScoiaTael,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -7724,7 +7724,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Dwarf},
                     Flavor = "怎么了，公主？吃不惯野味吗？嗯？",
-                    Info = "增益自身等同于最后打出的非同名“矮人”单位牌的初始战力。",
+                    Info = "增益自身等同于本小局打出的“矮人”单位牌的最强基础战力。",
                     CardArtsId = "20008000",
                 }
             },
@@ -9110,7 +9110,7 @@ namespace Cynthia.Card
                     IsDoomed = false,
                     IsCountdown = false,
                     IsDerive = false,
-                    Categories = new Categorie[]{ Categorie.ClanAnCraite},
+                    Categories = new Categorie[]{ Categorie.ClanAnCraite,Categorie.Machine},
                     Flavor = "只消对尼弗迦德人提起这个名字，他们就会吓得尿裤子……",
                     Info = "回合结束时，使左侧单位获得1点强化，右侧单位收到1点伤害。5点护甲。",
                     CardArtsId = "15210900",
@@ -10195,7 +10195,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.ClanDrummond,Categorie.Soldier},
                     Flavor = "我们的敌人会像打上嶙峋海岸的波浪一样，倒在我们的盾前。",
-                    Info = "召唤所有同名牌。",
+                    Info = "对一个敌军单位造成2点伤害，若目标已受伤，从卡组打出1张自身同名牌。",
                     CardArtsId = "15231810",
                 }
             },
@@ -10436,7 +10436,7 @@ namespace Cynthia.Card
                     IsDerive = true,
                     Categories = new Categorie[]{ Categorie.Cursed,Categorie.Token},
                     Flavor = "“呃，座头鲸应该没那么大。那是头长须鲸。”“嘴那么短的长须鲸？你被药草冲昏了头吗！”",
-                    Info = "回合结束时移至随机排，对同排所有其他单位造成1点伤害。 间谍。",
+                    Info = "回合结束时移至随机排，对同排所有其他单位造成1点伤害。遗愿：再次触发此能力。间谍。",
                     CardArtsId = "15240300",
                 }
             },
@@ -11133,6 +11133,26 @@ namespace Cynthia.Card
                 }
             },
             {
+                "70033",//战象
+                new GwentCard()
+                {
+                    CardId = "70033",
+                    Name = "战象",
+                    Strength = 10,
+                    Group = Group.Silver,
+                    Faction = Faction.NorthernRealms,
+                    CardUseInfo = CardUseInfo.MyRow,
+                    CardType = CardType.Unit,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = false,
+                    Categories = new Categorie[] { Categorie.Beast },
+                    Flavor = "“样子有点像浑身没毛的鹿首魔，鼻子能拖到地上。”\n“什么？不，你这是在胡扯”",
+                    Info = "摧毁己方半场单排所有单位的护甲，并造成扣除护甲值的伤害。",
+                    CardArtsId = "d19990000",
+                }
+            },
+            {
                 "70038",//西格瓦尔德
                 new GwentCard()
                 {
@@ -11145,7 +11165,7 @@ namespace Cynthia.Card
                     CardType = CardType.Unit,
                     IsDoomed = false,
                     IsCountdown = false,
-                    Categories = new Categorie[] {Categorie.Soldier,Categorie.Cursed},
+                    Categories = new Categorie[] {Categorie.Soldier,Categorie.Cursed,Categorie.Cultist},
                     Flavor = "能活够一定年岁的维尔卡战士会赢得整个家族的尊敬。",
                     Info = "回合结束时，复活至随机排，并获得1点强化。",
                     CardArtsId = "d16710000",


### PR DESCRIPTION
幽灵鲸
遗愿：同排

大狮鹫
原效果 + 移动对方墓场一个铜色单位
（老效果思路）
10->9

先祖麦酒
+回合结束后

中邪的女术士
+同排其他诅咒单位数量的伤害

泽维尔·莫兰
=>增益自身等同于本小局打出的最强的“矮人”单位牌的基础战力。

阿尔巴师枪兵
战力3=>4
白板一拉二=>回合结束时，从卡组召唤1张自身同名牌
（还原老版本效果）

德拉蒙特持盾女卫
白板一拉二=>对一个单位造成1点伤害，若其受伤，从卡组打出1张自身同名牌
（还原老版本效果）

修复: 维伯约恩bug修复
修复：西格瓦的呓语标签
女蛇妖6->7
冰霜巨人6->7
海上野猪-机械标签

北方新卡：
战象