### PR TITLE
修复特殊牌恐狼掷击被打出后会以单位形式呈现的问题

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -11180,7 +11180,7 @@ namespace Cynthia.Card
                     Strength = 0,
                     Group = Group.Copper,
                     Faction = Faction.Skellige,
-                    CardUseInfo = CardUseInfo.MyRow,
+                    CardUseInfo = CardUseInfo.AnyPlace,
                     CardType = CardType.Special,
                     IsDoomed = false,
                     IsCountdown = false,


### PR DESCRIPTION
修复特殊牌恐狼掷击被打出后会以单位形式呈现的问题