### PR TITLE
添加自动building测试

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,0 +1,21 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ diy ]
+  pull_request:
+    branches: [ diy ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Build
+      run: dotnet build ./src/Cynthia.Card/src/Cynthia.Card.Server/Cynthia.Card.Server.csproj


### PR DESCRIPTION
在每次对diy服务器push或者pr的时候都会自动化测试一下是否能building成功

pr在master是因为只有在默认分支上才有效

也不知道有没有用。。反正可以先加上？

merge或close后可以删除本分支