### PR TITLE
bug修复及平衡性调整

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/Monsters/DetlaffCrimsonCurse.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/Monsters/DetlaffCrimsonCurse.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public DetlaffCrimsonCurse(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-            var list = Game.PlayersCemetery[Card.PlayerIndex].Where(x => x.HasAnyCategorie(Categorie.Blitz,Categorie.Vampire)).ToList();
+            var list = Game.PlayersCemetery[Card.PlayerIndex].Where(x => x.HasAnyCategorie(Categorie.Beast,Categorie.Vampire)).ToList();
             //如果没有单位，什么都不做
             if (list.Count() == 0)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/Neutral/Highwaymen.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/Neutral/Highwaymen.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public bool IsUse { get; set; } = false;  
         public override async Task<int> CardUseEffect()
         {
-            if (IsUse)
+            if (IsUse || (Game.PlayerBaseDeck[PlayerIndex].Deck.Any(x => x.IsAnyGroup(Group.Gold,Group.Silver))))
             {
                 return 0;
             }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/Neutral/LivingArmor.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/Neutral/LivingArmor.cs
@@ -7,8 +7,13 @@ namespace Cynthia.Card
 {
     [CardEffectId("70062")]//活体盔甲 Living Armor
     public class LivingArmor : CardEffect, IHandlesEvent<BeforeCardDamage>
-    {//自身和己方半场同排铜色/银色单位一次最多受到5点伤害。
+    {//己方半场同排其他单位一次最多受到5点伤害。
         public LivingArmor(GameCard card) : base(card) { }
+        public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
+        {
+            await Card.Effect.Armor(2,Card);
+            return 0;
+        }
         public async Task HandleEvent(BeforeCardDamage @event)
         {
             //不在场上，返回
@@ -18,7 +23,7 @@ namespace Cynthia.Card
             }
 
             var currentRow = Card.Status.CardRow;
-            if (@event.Target.Status.CardRow == currentRow && @event.Target.PlayerIndex == Card.PlayerIndex )
+            if (@event.Target.Status.CardRow == currentRow && @event.Target.PlayerIndex == Card.PlayerIndex && @event.Target != Card)
             {
                 if(@event.Num>5)
                 {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/ProDerive/SavageBearPro.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/ProDerive/SavageBearPro.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
 
         public async Task HandleEvent(AfterUnitDown @event)
         {
-            if (Card.PlayerIndex != @event.Target.PlayerIndex && Card.Status.CardRow.IsOnPlace())
+            if (Card.PlayerIndex != @event.Target.PlayerIndex && Card.Status.CardRow.IsOnPlace() && !(@event.IsMoveInfo.isMove && !@event.IsMoveInfo.isFromeEnemy))
             {
                 await @event.Target.Effect.Damage(1, Card);
             }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/ScoiaTael/FeignDeath.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Expantion01/ScoiaTael/FeignDeath.cs
@@ -16,10 +16,10 @@ namespace Cynthia.Card
             && x.Status.Strength > 4).ToList();
             //让玩家选择
             var result = await Game.GetSelectMenuCards(Card.PlayerIndex, list, 2, isCanOver: true);
-            foreach (var x in result.ToList())
+            for(int i=result.Count()-1;i>=0;i++)
             {
-                await x.Effect.Resurrect(new CardLocation() { RowPosition = RowPosition.MyStay, CardIndex = 0 }, Card);
-                await x.Effect.Damage(4, Card);
+                await result[i].Effect.Resurrect(new CardLocation() { RowPosition = RowPosition.MyStay, CardIndex = 0 }, Card);
+                await result[i].Effect.Damage(4, Card);
             }
             return result.Count();
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Gold/Vernossiel.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/ScoiaTael/Gold/Vernossiel.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("70044")]//弗妮希尔
     public class Vernossiel : CardEffect
-    {//将3张“弗妮希尔的突击队”加入对方牌组。触发1次对方牌组中所有“弗妮希尔的突击队”的交换效果。
+    {//将2张“弗妮希尔的突击队”加入对方牌组。触发1次牌组中所有“弗妮希尔的突击队”的交换效果。
         public Vernossiel(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/HeymaeySkald.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/HeymaeySkald.cs
@@ -7,7 +7,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("64006")]//海玫家族诗人
     public class HeymaeySkald : CardEffect
-    {//使所选“家族”的所有友军单位获得1点增益。
+    {//使所选“家族”的所有友军单位获得2点增益。
         public HeymaeySkald(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -27,7 +27,7 @@ namespace Cynthia.Card
                 var list = Game.GetPlaceCards(Card.PlayerIndex).FilterCards(filter: x => x.HasAnyCategorie(famcat) && x != Card);
                 foreach (var card in list)
                 {
-                    await card.Effect.Boost(1, Card);
+                    await card.Effect.Boost(2, Card);
                 }
             }
             return 0;

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 31);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 32);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 
@@ -315,7 +315,7 @@ namespace Cynthia.Card
                 {
                     CardId ="12009",
                     Name="先祖麦酒",
-                    Strength=8,
+                    Strength=10,
                     Group=Group.Gold,
                     Faction = Faction.Neutral,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -9794,7 +9794,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.ClanHeymaey,Categorie.Support},
                     Flavor = "海玫家族的事迹将流芳千古。",
-                    Info = "使所选“家族”的所有友军单位获得1点增益。",
+                    Info = "使所选“家族”的所有友军单位获得2点增益。",
                     CardArtsId = "15230800",
                 }
             },
@@ -11297,7 +11297,7 @@ namespace Cynthia.Card
                 {
                     CardId ="70044",
                     Name="弗妮希尔",
-                    Strength=4,
+                    Strength=5,
                     Group=Group.Gold,
                     Faction = Faction.ScoiaTael,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -11418,7 +11418,7 @@ namespace Cynthia.Card
                 {
                     CardId ="70062",
                     Name="活体盔甲",
-                    Strength=10,
+                    Strength=13,
                     Group = Group.Gold,
                     Faction = Faction.Neutral,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -11428,7 +11428,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[] { Categorie.Construct},
                     Flavor = "价钱是贵了点。但是你把节省下来的吃住都算进去，不出一百年就能回本！",
-                    Info = "己方同排单位单次最多受到5点伤害。", 
+                    Info = "己方同排其他单位单次最多受到5点伤害。2点护甲。", 
                     CardArtsId = "d19280000",
                 }
             },


### PR DESCRIPTION
bug修复：路途埋伏(触发条件失效)，恶熊晋升（对位移单位生效），猩红诅咒（对野兽不生效，假死（打出顺序和选择顺序相反）。
加强：先祖麦酒 8->10,弗妮希尔 4->5，海玫家族诗人buff 1->2，活体盔甲战力及效果调整