### PR TITLE
bugfix: lock removes shield 锁定移除护盾

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -644,6 +644,7 @@ namespace Cynthia.Card
                     await Card.Effect.Resilience(source);
                 if (Card.Status.Conceal)
                     await Card.Effect.Ambush();
+                Card.Status.IsShield = false;
                 await Game.ShowSetCard(Card);
             }
             //8888888888888888888888888888888888888888888888888888888888888888888888


### PR DESCRIPTION
修复将卡牌锁定时护盾不会被移除的bug