### PR TITLE
fix(HawkerSmuggler): ignore moving

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/HawkerSmuggler.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/HawkerSmuggler.cs
@@ -14,7 +14,7 @@ namespace Cynthia.Card
 
         public async Task HandleEvent(AfterUnitDown @event)
         {
-            if (@event.Target.PlayerIndex != Card.PlayerIndex && Card.Status.CardRow.IsOnPlace())
+            if (@event.Target.PlayerIndex != Card.PlayerIndex && Card.Status.CardRow.IsOnPlace() && !@event.IsMoveInfo.isMove)
             {
                 await Card.Effect.Boost(boost, Card);
             }


### PR DESCRIPTION
私枭走私者忽略移动的单位