### PR TITLE
fix(Mangonel): misleading card text

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Locales/en.json
@@ -1583,7 +1583,7 @@
         },
         "34016": {
             "Name": "Mangonel",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal this card.",
+            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal a card.",
             "Flavor": "适用于投掷残骸和干粪。"
         },
         "34017": {

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
@@ -1583,7 +1583,7 @@
         },
         "34016": {
             "Name": "Mangonel",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal this card.",
+            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal a card.",
             "Flavor": "适用于投掷残骸和干粪。"
         },
         "34017": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -1583,7 +1583,7 @@
         },
         "34016": {
             "Name": "Mangonel",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal this card.",
+            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal a card.",
             "Flavor": "适用于投掷残骸和干粪。"
         },
         "34017": {


### PR DESCRIPTION
Old text was incorrect and did not match the actual (and intended) behavior.