### PR TITLE
fix: fix mongodb connection string for old version of docker (less then 3.7)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3.2'
 
 services:
   db:
@@ -7,8 +7,6 @@ services:
       - "28020:27017"
     volumes:
       - db-vloume:/data/db
-    networks:
-      - db
 
   server:
     build:
@@ -16,13 +14,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5005:5005"
-    networks:
-      - db
+    environment:
+      - MONGO_CONNECTION_STRING=mongodb://host.docker.internal:28020/gwent-diy
     depends_on:
       - db
 
 volumes:
   db-vloume:
-
-networks:
-  db:

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Startup.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Startup.cs
@@ -31,14 +31,7 @@ namespace Cynthia.Card.Server
             services.AddSingleton<Random>(x => new Random((int)DateTime.UtcNow.Ticks));
             services.AddAntDesign();
             services.AddBlazoredLocalStorage();
-            if (_env.IsDevelopment())
-            {
-                services.AddTransient<IMongoClient, MongoClient>(x => new MongoClient("mongodb://localhost:28020/gwent-diy"));
-            }
-            else
-            {
-                services.AddTransient<IMongoClient, MongoClient>(x => new MongoClient("mongodb://localhost:28020/gwent-diy"));
-            }
+            services.AddTransient<IMongoClient, MongoClient>(x => new MongoClient(GetConnectionString()));
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
@@ -60,6 +53,17 @@ namespace Cynthia.Card.Server
                 endpoints.MapFallbackToPage("/_Host");
                 endpoints.MapHub<GwentHub>("/hub/gwent");
             });
+        }
+        
+        private string GetConnectionString()
+        {
+            string variable = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING");
+            Console.WriteLine(variable);
+            if (string.IsNullOrEmpty(variable))
+            {
+                return "mongodb://localhost:28020/gwent-diy";
+            }
+            return variable;
         }
     }
 }


### PR DESCRIPTION
Fix what on old versions of docker (and maybe only on linux) the connection string `mongodb://db:28020/gwent-diy` won't work. 
Change it to `mongodb://host.docker.internal:28020/gwent-diy` and expose it to an enviroment variable `MONGO_CONNECTION_STRING`

By default, the `MONGO_CONNECTION_STRING` is `mongodb://localhost:28020/gwent-diy`, so you don't need to change it for production/debug builds. It is used only in docker-compose builds.