### PR TITLE
Fix EN cards descriptions

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -333,7 +333,7 @@
         },
         "12022": {
             "Name": "Regis: Higher Vampire",
-            "Info": "Deploy: Look at 3 Bronze units from your opponent's deck.\nConsume 1, then Boost self by its base Power.",
+            "Info": "Deploy: Look at the top 3 Bronze units from your opponent's deck.\nConsume 1, then Boost self by its base Power.",
             "Flavor": "He becomes invisible at will. His glance hypnotizes into a deep sleep. He then drinks his fill, turns into a bat and flies off. Altogether uncouth."
         },
         "12023": {
@@ -1328,7 +1328,7 @@
         },
         "31001": {
             "Name": "Jan Calveit",
-            "Info": "Deploy: Look at 3 cards from your deck, then play 1.",
+            "Info": "Deploy: Look at the top 3 cards from your deck, then play 1.",
             "Flavor": "剑只是统治者的工具之一。"
         },
         "31004": {
@@ -1558,7 +1558,7 @@
         },
         "34011": {
             "Name": "Rot Tosser",
-            "Info": "Deploy: Spawn a Cow Carcass on an enemy row.",
+            "Info": "Deploy: Spawn a Cow Carcass on an enemy row.\n(After 2 turns, on turn end, destroy all the other Lowest units on the row and destroy self).",
             "Flavor": "向围城中散播瘟疫是否人道，这个话题还是留给史学家吧。我们只关心这法子有没有效。"
         },
         "34012": {
@@ -1663,7 +1663,7 @@
         },
         "34001": {
             "Name": "Vicovaro Novice",
-            "Info": "Deploy: Draw the top 2 Bronze Alchemy cards from your deck.\nPlay 1 and shuffle the other back.",
+            "Info": "Deploy: Look at 2 random Bronze Alchemy cards from your deck.\nPlay 1 and shuffle the other back.",
             "Flavor": "尼弗迦德的法师们就像手纸。一旦谁被皇帝厌倦，立刻有大把新人迫不及待地赶来补缺。"
         },
         "34029": {
@@ -1698,7 +1698,7 @@
         },
         "35002": {
             "Name": "Cow Carcass",
-            "Info": "Spying.\nAfter 2 turns, destroy all the other Lowest units on the row and destroy self on turn end.",
+            "Info": "Spying.\nAfter 2 turns, on turn end, destroy all the other Lowest units on the row and destroy self.",
             "Flavor": "那是只鸟？还是头狮鹫？不对！那是……"
         },
         "41001": {
@@ -1788,7 +1788,7 @@
         },
         "43001": {
             "Name": "Thaler",
-            "Info": "Spying. Single-Use.\nDeploy: Draw 2 cards, keep one and shuffle the other back to your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Draw 2 cards.\nKeep one and shuffle the other to your deck.",
             "Flavor": "滚开！我们中间不是每个人都那么轻浮、那么浅薄……"
         },
         "43002": {
@@ -2043,7 +2043,7 @@
         },
         "44031": {
             "Name": "Tormented Mage",
-            "Info": "Deploy: Look at 2 Bronze Spells or Items from your deck, then play 1.",
+            "Info": "Deploy: Look at 2 random Bronze Spells or Items from your deck, then play 1.",
             "Flavor": "萨宾娜·葛丽维希格的诅咒摧枯拉朽。面对这股怒火，就连法师们也束手无策。"
         },
         "44032": {
@@ -2938,7 +2938,7 @@
         },
         "70025": {
             "Name": "Syanna",
-            "Info": "Single-use.\nRepeat the Deploy ability of the next Bronze or Silver loyal unit you play.\n4 Armor.",
+            "Info": "Single-Use.\nRepeat the Deploy ability of the next Bronze or Silver loyal unit you play.\n4 Armor.",
             "Flavor": "Your Majesty... The princess has been touched by the curse o' the Black Sun. There's no hope, I'm afraid..."
         },
         "70026": {
@@ -3033,12 +3033,12 @@
         },
         "70070": {
             "Name": "Highwaymen",
-            "Info": "Single-use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two copies of Strays of Spalla to your deck.",
+            "Info": "Single-Use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two copies of Strays of Spalla to your deck.",
             "Flavor": "“商人？抹了。马匹？卖了。”"
         },
         "70071": {
             "Name": "Strays Of Spalla",
-            "Info": "Single-use.\nLook at 2 random Bronze units in your deck, then play one.",
+            "Info": "Single-Use.\nLook at 2 random Bronze units in your deck, then play one.",
             "Flavor": "“嗷，嗷，嗷嗷！”"
         },
         "70072": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -353,7 +353,7 @@
         },
         "12026": {
             "Name": "Triss: Telekinesis",
-            "Info": "Deploy: Create and play a bronze special card from either player's starting deck.",
+            "Info": "Deploy: Create and play a Bronze special card from either player's starting deck.",
             "Flavor": "Bindings won't suffice. Nor will a gag render her any less dangerous. No, dimeritium is the only solution."
         },
         "12002": {
@@ -513,7 +513,7 @@
         },
         "13015": {
             "Name": "Olgierd von Everec",
-            "Info": "Deathwish: Resurrect this unit on a random row.",
+            "Info": "Deathwish: Resurrect this unit on the same location.",
             "Flavor": "至少你知道我的头不好砍了。"
         },
         "13002": {
@@ -1098,7 +1098,7 @@
         },
         "24004": {
             "Name": "Archgriffin",
-            "Info": "Deploy: Clear Hazards on its row. Move a bronze unit card from the opponent's graveyard to your own graveyard.",
+            "Info": "Deploy: Clear Hazards on its row. Move a Bronze unit from the opponent's graveyard to your own graveyard.",
             "Flavor": "大狮鹫也是狮鹫，只是更加凶悍。"
         },
         "24005": {
@@ -1118,7 +1118,7 @@
         },
         "24008": {
             "Name": "Griffin",
-            "Info": "Deploy: Trigger the Deathwish of a Bronze Ally.",
+            "Info": "Deploy: Trigger the Deathwish of a Bronze ally.",
             "Flavor": "Griffins like to toy with their prey. Eat 'em alive, piece by piece."
         },
         "24009": {
@@ -1163,7 +1163,7 @@
         },
         "24017": {
             "Name": "Werewolf",
-            "Info": "Boost by 7 on contact with Full Moon. Immune.",
+            "Info": "Boost by 7 on contact with Full Moon.\nImmune.",
             "Flavor": "有人说，如果被狼人咬了，那么你就会被感染，也变成狼人。当然，猎魔人都知道这是胡说八道。只有强大的诅咒才能造成这种效果。"
         },
         "24018": {
@@ -1292,7 +1292,7 @@
             "Flavor": "鹰身女妖蛋卷，真是美味佳肴啊，好先生。但它也非常昂贵，您可能料得到，这些可怜的鸟儿并不愿跟自己的蛋分离。"
         },
         "25005": {
-            "Name": "25005",
+            "Name": "Harpy Hatchling",
             "Info": "No ability.",
             "Flavor": "有时候，“年轻即是美”不过是大自然的谎言罢了。"
         },
@@ -1407,8 +1407,8 @@
             "Flavor": "猎魔人绝不会死在自己的床上。"
         },
         "32015": {
-            "Name": "Treason",
-            "Info": "Damage Enemies by 9 and then 9",
+            "Name": "Assassination",
+            "Info": "Deal 9 damage to an enemy.\nRepeat once.",
             "Flavor": "“请你出手要多少钱？” “看情况喽。比如说目标是你，大改100奥伦币左右。”"
         },
         "33004": {
@@ -1448,12 +1448,12 @@
         },
         "33009": {
             "Name": "Hefty Helge",
-            "Info": "Deploy: If this Unit was Revealed, Damage all Enemies by 1. Otherwise, Damage all Enemies except those on opposite row by 1.",
+            "Info": "Deploy: If this unit was Revealed, Damage all Enemies by 1. Otherwise, Damage all enemies except those on opposite row by 1.",
             "Flavor": "并非攻城的最佳选择，却是毁城的行家里手。"
         },
         "33010": {
             "Name": "Auckes",
-            "Info": "Deploy: Lock 2 Units.",
+            "Info": "Deploy: Toggle 2 units' Lock statuses.",
             "Flavor": "雷索已有计划……还能出什么岔子？"
         },
         "33011": {
@@ -1468,7 +1468,7 @@
         },
         "33013": {
             "Name": "Cynthia",
-            "Info": "Deploy: Reveal the Highest Unit in your opponent's Hand and Boost self by its Power.",
+            "Info": "Deploy: Reveal the Highest unit in your opponent's Hand and Boost self by its Power.",
             "Flavor": "决不能轻视辛西亚，必须把她看紧点儿。"
         },
         "33001": {
@@ -1483,7 +1483,7 @@
         },
         "33015": {
             "Name": "Vanhemar",
-            "Info": "Deploy: Spawn Frost, Clear Skies or Overdose.",
+            "Info": "Deploy: Spawn Frost, Clear Skies or Shrike.",
             "Flavor": "作为火法师，他算不上……多么热烈。"
         },
         "33016": {
@@ -1503,7 +1503,7 @@
         },
         "33019": {
             "Name": "Dazhbog Runestone",
-            "Info": "Create and play a Bronze or Silver Nilfgaard card.",
+            "Info": "Create a Bronze or Silver Nilfgaard card.",
             "Flavor": "当心。还烫着呢。"
         },
         "33020": {
@@ -1513,7 +1513,7 @@
         },
         "33021": {
             "Name": "Cadaverine",
-            "Info": "Deal 3 damage to an enemy and all units that share its categories; or destroy a Bronze or Silver Neutral unit.",
+            "Info": "Choose One: Deal 3 damage to an enemy and all units that share its categories; or destroy a Bronze or Silver Neutral unit.",
             "Flavor": "我不会拿自己的性命去碰运气。我会拿上一把长剑，厚厚地涂上一层吊死鬼之毒。"
         },
         "33022": {
@@ -1613,12 +1613,12 @@
         },
         "34020": {
             "Name": "Nauzicaa Brigade",
-            "Info": "Deploy: Damage a Spying Unit by 7. If it was Destroyed, Strengthen self by 4.",
+            "Info": "Deploy: Damage a Spying unit by 7. If it was Destroyed, Strengthen self by 4.",
             "Flavor": "我们被称作死神头。想知道为什么吗？"
         },
         "34021": {
             "Name": "Spotter",
-            "Info": "Deploy: Choose a bronze or silver Revealed Unit in either Hand and Boost self by its base Power.",
+            "Info": "Deploy: Choose a Bronze or Silver Revealed unit in either Hand and boost self by its base Power.",
             "Flavor": "北方佬耍不出花招了。"
         },
         "34022": {
@@ -1698,7 +1698,7 @@
         },
         "35002": {
             "Name": "Cow Carcass",
-            "Info": "After 2 turns, destroy the weakest non-Gold unit(s) on the row (except self). Banish when moved to the graveyard.",
+            "Info": "Spying.\nAfter 2 turns, destroy all the other Lowest units on the row and destroy self on turn end.",
             "Flavor": "那是只鸟？还是头狮鹫？不对！那是……"
         },
         "41001": {
@@ -1798,7 +1798,7 @@
         },
         "43003": {
             "Name": "Trollololo",
-            "Info": "4 Armor. At the start of your turn, gain 2 Armor.",
+            "Info": "At the start of your turn, gain 2 Armor. 4 Armor.",
             "Flavor": "我是拉多多德国王的兵兵。收到命令，看守船船。"
         },
         "43004": {
@@ -1848,7 +1848,7 @@
         },
         "43013": {
             "Name": "Dethmold",
-            "Info": "Deploy: Spawn Rain, Clear Skies or Alzur's Thunder.",
+            "Info": "Deploy: Spawn Torrential Rain, Clear Skies or Alzur's Thunder.",
             "Flavor": "我曾让一个囚犯搜肠刮肚地狂吐……啊，好怀念……"
         },
         "43014": {
@@ -2053,12 +2053,12 @@
         },
         "44033": {
             "Name": "Winch",
-            "Info": "Choose one: Play a bronze Mechanical card from your graveyard and make it Doomed; Or boost all machines on your side of the board by 3.",
+            "Info": "Choose One: Resurrect a Bronze Machine and add the Doomed category to it; or boost all machines on your side of the board by 3.",
             "Flavor": "就是一个绞盘。没什么可大惊小怪的。"
         },
         "44034": {
             "Name": "Bloody Flail",
-            "Info": "Deal 5 damage and Spawn a Specter.",
+            "Info": "Deal 5 damage and Spawn a Specter on a random row.",
             "Flavor": "有些武器在整个北方领域都禁止使用。因为它们所造成的伤害超出了人们的想象。"
         },
         "45001": {
@@ -2248,7 +2248,7 @@
         },
         "53018": {
             "Name": "Morana Runestone",
-            "Info": "Create and play a Bronze or Silver Scoia'tael card.",
+            "Info": "Create a Bronze or Silver Scoia'tael card.",
             "Flavor": "一看到它我就头晕……"
         },
         "53019": {
@@ -2268,7 +2268,7 @@
         },
         "54001": {
             "Name": "Vrihedd Sappers",
-            "Info": "Ambush: After 2 turns, flip over. ",
+            "Info": "Ambush: After 2 turns, on turn start, flip over. ",
             "Flavor": "不管流言怎么说，精灵才不会碰人类的头皮。因为虱子太多了。"
         },
         "54002": {
@@ -2293,7 +2293,7 @@
         },
         "54006": {
             "Name": "Farseer",
-            "Info": "If a different Ally or Unit in your Hand is Boosted during your turn, Boost self by 2 at the end of the turn.",
+            "Info": "If a different Ally or unit in your hand is Boosted during your turn, boost self by 2 at the end of the turn.",
             "Flavor": "有时候，他的话语听似令人费解，但其中总是蕴藏着深邃的道理和惊人的智慧。"
         },
         "54007": {
@@ -2573,7 +2573,7 @@
         },
         "63016": {
             "Name": "Gremist",
-            "Info": "Deploy: Spawn Rain, Clear Skies or Roar.",
+            "Info": "Deploy: Spawn Torrential Rain, Clear Skies or Bloodcurdling Roar.",
             "Flavor": "精通炼金术的大德鲁伊，也是群岛脾气最差的老混蛋。"
         },
         "63017": {
@@ -2588,7 +2588,7 @@
         },
         "63019": {
             "Name": "Restore",
-            "Info": "Return a Bronze or Silver Skellige Unit from your Graveyard to your Hand and set its base Power to 8, then play a card from your Hand.",
+            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base power to 8. Then play a card.",
             "Flavor": "那些该死的女术士又抢咱们的风头！只要几个年轻姑娘挥挥手就能解决的话，谁还选择这么费时费力的办法？"
         },
         "63020": {
@@ -2793,12 +2793,12 @@
         },
         "65006": {
             "Name": "Wilhelm",
-            "Info": "Deathwish: Damage all Unis on the opposite row by 1.",
+            "Info": "Deathwish: Damage all units on the opposite row by 1.",
             "Flavor": "高个子的是威尔玛。他右边的是威尔弗雷德。结巴的那个是威尔海姆。"
         },
         "65007": {
             "Name": "Wilmar",
-            "Info": "Deathwish: The opposing player plays a random Bronze Cursed Unit from their Deck.",
+            "Info": "Spying.\nDeathwish: Spawn an Elder Bear on the opposite row.",
             "Flavor": "高个子的是威尔玛。他右边的是威尔弗雷德。结巴的那个是威尔海姆。"
         },
         "61001": {
@@ -2823,17 +2823,17 @@
         },
         "70001": {
             "Name": "Quen",
-            "Info": "Choose a bronze/silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them shield. The shield can block any damage once.",
+            "Info": "Choose a Bronze or Silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them shield. The shield can block any damage once.",
             "Flavor": ""
         },
         "70002": {
             "Name": "Detlaff: Higher Vampire",
-            "Info": "Deploy, Choose one: Play a bronze unit from your deck with power equal to or less than this unit's. Send it to the graveyard at the end of the turn; or Consume a bronze unit from your deck with more power than this unit and gain its power.",
+            "Info": "Deploy, Choose one: Play a Bronze unit from your deck with power equal to or less than this unit's. Send it to the graveyard at the end of the turn; or Consume a bronze unit from your deck with more power than this unit and gain its power.",
             "Flavor": ""
         },
         "70003": {
             "Name": "Hammond",
-            "Info": "Deploy, Choose one: Create a Skellige bronze machine unit; or Boost all friendly machines on the board by 2.\nUnits in this row are immune to damage from hazards.",
+            "Info": "Deploy, Choose one: Spawn a Skellige Bronze Machine unit; or Boost all friendly machines on the board by 2.\nUnits in this row are immune to damage from hazards.",
             "Flavor": ""
         },
         "70004": {
@@ -2858,7 +2858,7 @@
         },
         "70008": {
             "Name": "Vivienne: Oriole",
-            "Info": "On turn end, if your total power exceeds the opponent's power by 25 points or more, return to your hand.",
+            "Info": "On turn end, if your total power exced nent's power by 25 points or more, return to your hand.",
             "Flavor": ""
         },
         "70009": {
@@ -2868,7 +2868,7 @@
         },
         "70010": {
             "Name": "Protofleder",
-            "Info": "Deploy: Shuffle a \"Fleder\" to the top of your deck.\nWhenever a bronze/silver enemy unit becomes injured, boost self by 2.",
+            "Info": "Deploy: Shuffle a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy comes injured, boot self by 2.",
             "Flavor": ""
         },
         "70011": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -2858,17 +2858,17 @@
         },
         "70008": {
             "Name": "Vivienne: Oriole",
-            "Info": "On turn end, if your total power exced nent's power by 25 points or more, return to your hand.",
+            "Info": "On turn end, if your total power exceeds the opponent's power by 25 points or more, return to your hand.",
             "Flavor": ""
         },
         "70009": {
             "Name": "Fleder",
-            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a bronze/silver enemy unit becomes damaged, boost self by 1.",
+            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy unit becomes damaged, boost self by 1.",
             "Flavor": ""
         },
         "70010": {
             "Name": "Protofleder",
-            "Info": "Deploy: Shuffle a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy comes injured, boot self by 2.",
+            "Info": "Deploy: Shuffle a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy becomes injured, boost self by 2.",
             "Flavor": ""
         },
         "70011": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -268,7 +268,7 @@
         },
         "12009": {
             "Name": "Ale of the Ancestors",
-            "Info": "Deploy: Apply Golden Froth to the row.\nRepeat its ability when moved, then deal 4 Damage to self.",
+            "Info": "Deploy: Apply Golden Froth to the row.\nWhen moved, repeat its ability, then deal 4 Damage to self.",
             "Flavor": "Boros, the legendary founder of Clan Fuchs, died after overindulging in this beverage - he passed out while reaching for his golden ring, which had fallen into a brook."
         },
         "12010": {
@@ -298,7 +298,7 @@
         },
         "12015": {
             "Name": "Zoltan: Scoundrel",
-            "Info": "Deploy, Choose One: Spawn a Duda: Companion that Boosts 2 units on each side of it by 2; or Spawn a Duda: Agitator that deals 2 Damage to 2 units on each side of it.",
+            "Info": "Deploy, Choose One: Spawn a Duda: Agitator that deals 2 Damage to 2 units on each side of it; or Spawn a Duda: Companion that Boosts 2 units on each side of it by 2.\n(Duda; 1 Strength)",
             "Flavor": "Apologies. My exotic pet's a clever birdie, but a wee bit lewd. Paid ten thalers for the beaute."
         },
         "12016": {
@@ -323,7 +323,7 @@
         },
         "12020": {
             "Name": "Gaunter O'Dimm",
-            "Info": "Deploy, Gamble with Gaunter: Guess whether the Power of the card he picked is less, equal or greater than 6.",
+            "Info": "Deploy, Gamble with Gaunter: Guess whether the Power of the random card he picked is lower, equal or higher than 6.\nIf guessed, you can play that card.",
             "Flavor": "He always grants exactly what you wish for. That's the problem."
         },
         "12021": {
@@ -343,7 +343,7 @@
         },
         "12024": {
             "Name": "Yennefer",
-            "Info": "Deploy, Choose One: Spawn a Unicorn that Boosts all other units by 2; or Spawn a Chironex that deals 2 Damage to all other units.",
+            "Info": "Deploy, Choose One: Spawn a Unicorn that Boosts all other units by 2; or Spawn a Chironex that deals 2 Damage to all other units.\n(Unicorn; 1 Strength)\n(Chironex; 4 Strength)",
             "Flavor": "Magic is Chaos, Art and Science. It is a curse, a blessing and a progression."
         },
         "12025": {
@@ -353,7 +353,7 @@
         },
         "12026": {
             "Name": "Triss: Telekinesis",
-            "Info": "Deploy: Create and play a Bronze special card from either player's starting deck.",
+            "Info": "Deploy: Create a Bronze special card from either player's starting deck.",
             "Flavor": "Bindings won't suffice. Nor will a gag render her any less dangerous. No, dimeritium is the only solution."
         },
         "12002": {
@@ -433,7 +433,7 @@
         },
         "12039": {
             "Name": "Uma's Curse",
-            "Info": "Create a non-Leader Gold unit",
+            "Info": "Create a non-Leader Gold unit.",
             "Flavor": "I give you three solid leads, trails as fresh as morning dew, the aid of my spies and my court sorceress. Yet in my daughter's stead, you bring me this... monstrosity?"
         },
         "12040": {
@@ -463,7 +463,7 @@
         },
         "13005": {
             "Name": "Germain Piquant",
-            "Info": "Deploy: Spawn 2 Cows on each side of this unit.",
+            "Info": "Deploy: Spawn 2 Cows on each side of this unit.\n(Cow; 1 Strength)",
             "Flavor": "陶森特需要这位英雄，但它不配。"
         },
         "13006": {
@@ -478,7 +478,7 @@
         },
         "13008": {
             "Name": "Johnny",
-            "Info": "Deploy: Discard a card, then make a copy of a card of the same color from your opponent's starting deck in your hand.",
+            "Info": "Deploy: Discard a card, then add a copy of a card of the same color from your opponent's starting deck in your hand.",
             "Flavor": "要是再也没办法亲口说出“狮子头上长虱子”，生活就真的太无趣啦。"
         },
         "13009": {
@@ -493,7 +493,7 @@
         },
         "13011": {
             "Name": "Carlo Varese",
-            "Info": "Deploy: Deal 1 Damage for each card in your hand.",
+            "Info": "Deploy: Deal 1 Damage for each card in your hand, to an enemy.",
             "Flavor": "每个想要在诺维格瑞做生意的都很清楚——要么同意卡罗的条件，要么就夹着尾巴滚出去。"
         },
         "13012": {
@@ -523,7 +523,7 @@
         },
         "13016": {
             "Name": "Operator",
-            "Info": "Deploy, Single-Use, Truce: Make a default copy of a Bronze unit in your hand for both players.",
+            "Info": "Deploy, Single-Use, Truce: Add a default copy of a Bronze unit in your hand to both hands.",
             "Flavor": "时空在我们面前瓦解，也在我们身后膨胀，这就是穿越。"
         },
         "13017": {
@@ -558,7 +558,7 @@
         },
         "13022": {
             "Name": "Prize-Winning Cow",
-            "Info": "Deathwish: Spawn a Chort on a random row.",
+            "Info": "Deathwish: Spawn a Chort on a random row.\n(Chort; 14 Strength)",
             "Flavor": "哞～～～"
         },
         "13023": {
@@ -573,7 +573,7 @@
         },
         "13025": {
             "Name": "Artefact Compression",
-            "Info": "Transform a Bronze or Silver unit into a Jade Figurine.",
+            "Info": "Transform a Bronze or Silver unit into a Jade Figurine.\n(Jade Figurine; 2 Strength)",
             "Flavor": "雕像瞬间爆开，颤动不已，犹如一道在地上爬行的烟雾，变换着自己的形状。道道光芒里，有东西上下纷飞，不断成形。片刻之后，魔法圈的正中间突然现出了一道人影。"
         },
         "13026": {
@@ -633,7 +633,7 @@
         },
         "13037": {
             "Name": "The Last Wish",
-            "Info": "Draw your top 2 cards.\nPlay 1 and shuffle the other back.",
+            "Info": "Look at the top 2 cards from your deck.\nPlay 1 and shuffle the other back.",
             "Flavor": "亲爱的先生们，一只气灵三个愿望，随后它们就会跑回自己的界域去。"
         },
         "13038": {
@@ -693,7 +693,7 @@
         },
         "14006": {
             "Name": "Bloodcurdling Roar",
-            "Info": "Destroy an ally, then Spawn an Elder Bear",
+            "Info": "Destroy an ally, then Spawn an Elder Bear.\n(Elder Bear; 11 Strength)",
             "Flavor": "起初我们碰上了一头熊……悲剧就从那时开始了。"
         },
         "14007": {
@@ -793,7 +793,7 @@
         },
         "14025": {
             "Name": "Spores",
-            "Info": "Deal 2 Damage to all units on a row and clear a Boon from it.",
+            "Info": "Deal 2 Damage to all units on an enemy row and clear a Boon from it.",
             "Flavor": "吃够量，世界就会变个样……"
         },
         "14026": {
@@ -803,7 +803,7 @@
         },
         "14027": {
             "Name": "Peasant Militia",
-            "Info": "Spawn 3 Peasants on a row.",
+            "Info": "Spawn 3 Peasants on a row.\n(Peasant; 3 Strength)",
             "Flavor": "瞧，我们是民兵。我们保卫和平"
         },
         "15001": {
@@ -993,7 +993,7 @@
         },
         "23005": {
             "Name": "Colossal Ifrit",
-            "Info": "Deploy: Spawn 3 copies of Lesser Ifrit to the right of this unit.\n(When Summoned, deal 1 Damage to a random enemy)",
+            "Info": "Deploy: Spawn 3 Lesser Ifrits to the right of this unit.\n(Lesser Ifrit; 1 Strength; When Summoned, deal 1 Damage to a random enemy)",
             "Flavor": "受不了热浪？那就没生路了。"
         },
         "23006": {
@@ -1083,7 +1083,7 @@
         },
         "24001": {
             "Name": "Cyclops",
-            "Info": "Deploy: Destroy an ally and deal its Power as Damage.",
+            "Info": "Deploy: Destroy an ally and deal its Power as Damage to an enemy.",
             "Flavor": "别盯着它的眼睛，他不喜欢那样……"
         },
         "24002": {
@@ -1098,7 +1098,7 @@
         },
         "24004": {
             "Name": "Archgriffin",
-            "Info": "Deploy: Clear Hazards on its row.\nMove a Bronze unit from the opponent's graveyard to your own graveyard.",
+            "Info": "Deploy: Clear Hazards on its row.\nMove a Bronze unit from the opponent's graveyard to yours.",
             "Flavor": "大狮鹫也是狮鹫，只是更加凶悍。"
         },
         "24005": {
@@ -1128,7 +1128,7 @@
         },
         "24010": {
             "Name": "Arachas Behemoth",
-            "Info": "Whenever you Consume a unit, Spawn an Arachas Hatchling.\nRepeat up to 3 times.",
+            "Info": "Whenever you Consume a unit, Spawn an Arachas Hatchling.\nRepeat up to 3 times.\n(Arachas Hatchling; 3 Strength; Summon all Arachas Drones)",
             "Flavor": "看起来像螃蟹和蜘蛛的杂交……只是体型硕大无比。"
         },
         "24011": {
@@ -1168,7 +1168,7 @@
         },
         "24018": {
             "Name": "Celaeno Harpy",
-            "Info": "Deploy: Spawn 2 Harpy Eggs.",
+            "Info": "Deploy: Spawn 2 Harpy Eggs to its left.\n(Harpy Egg; 1 Strength; When Consumed by another unit, Boost that unit by an additional 5.\nDeathwish: Spawn a Harpy Hatchling on a random row)\n(Harpy Hatchling; 1 Strength)",
             "Flavor": "一般的鹰身女妖以腐肉为食，赛尔伊诺鹰身女妖……则以梦境为食。"
         },
         "24019": {
@@ -1223,7 +1223,7 @@
         },
         "24029": {
             "Name": "Ghoul",
-            "Info": "Deploy: Consume a Bronze or Silver unit from your graveyard. ",
+            "Info": "Deploy: Consume a Bronze or Silver unit from your graveyard and Boost self by its Power. ",
             "Flavor": "如果食尸鬼也是生死循环的一环……那这循环也太残酷了。"
         },
         "24030": {
@@ -1277,8 +1277,8 @@
             "Flavor": "它很容易被误认作岩石，许多糊涂巨魔已痛彻心扉地领悟到这一点。"
         },
         "25002": {
-            "Name": "Arachas Drone",
-            "Info": "Deploy: Summon all copies of this unit.",
+            "Name": "Arachas Hatchling",
+            "Info": "Summon all Arachas Drones.",
             "Flavor": "有时候，“年轻即是美”不过是大自然的谎言罢了。"
         },
         "25003": {
@@ -1288,7 +1288,7 @@
         },
         "25004": {
             "Name": "Harpy Egg",
-            "Info": "When Consumed by another unit, Boost that unit by an additional 5.\nDeathwish: Spawn a Harpy Hatchling on a random row.",
+            "Info": "When Consumed by another unit, Boost that unit by an additional 5.\nDeathwish: Spawn a Harpy Hatchling on a random row.\n(Harpy Hatchling; 1 Strength)",
             "Flavor": "鹰身女妖蛋卷，真是美味佳肴啊，好先生。但它也非常昂贵，您可能料得到，这些可怜的鸟儿并不愿跟自己的蛋分离。"
         },
         "25005": {
@@ -1558,7 +1558,7 @@
         },
         "34011": {
             "Name": "Rot Tosser",
-            "Info": "Deploy: Spawn a Cow Carcass on an enemy row.\n(After 2 turns, on turn end, destroy all the other Lowest units on the row and destroy self)",
+            "Info": "Deploy: Spawn a Cow Carcass on an enemy row.\n(Cow Carcass; 1 Strength; After 2 turns, on turn end, destroy all the other Lowest units on the row and destroy self)",
             "Flavor": "向围城中散播瘟疫是否人道，这个话题还是留给史学家吧。我们只关心这法子有没有效。"
         },
         "34012": {
@@ -1593,7 +1593,7 @@
         },
         "34018": {
             "Name": "Combat Engineer",
-            "Info": "Deploy: Toggle Resilience of an ally.\nCrew.",
+            "Info": "Deploy: Toggle the Resilience status of an ally.\nCrew.",
             "Flavor": "战争是文明进步的确凿证据——看看吧，现在大伙儿打仗更有效率了。"
         },
         "34003": {
@@ -2058,7 +2058,7 @@
         },
         "44034": {
             "Name": "Bloody Flail",
-            "Info": "Deal 5 Damage and Spawn a Specter on a random row.",
+            "Info": "Deal 5 Damage and Spawn a Specter on a random row.\n(Specter; 5 Strength)",
             "Flavor": "有些武器在整个北方领域都禁止使用。因为它们所造成的伤害超出了人们的想象。"
         },
         "45001": {
@@ -2438,7 +2438,7 @@
         },
         "62002": {
             "Name": "Hjalmar an Craite",
-            "Info": "Deploy: Spawn the Lord of Undvik on the opposite row.\n(Deathwish: Boost enemy Hjalmars by 10)",
+            "Info": "Deploy: Spawn the Lord of Undvik on the opposite row.\n(Lord of Undvik; 5 Strength; Deathwish: Boost enemy Hjalmars by 10)",
             "Flavor": "別为死者哭泣，敬他们一杯吧！"
         },
         "62003": {
@@ -2483,7 +2483,7 @@
         },
         "62011": {
             "Name": "Coral",
-            "Info": "Deploy: Transform a Bronze or Silver unit into a Jade Figurine.",
+            "Info": "Deploy: Transform a Bronze or Silver unit into a Jade Figurine\n(Jade Figurine; 2 Strength)",
             "Flavor": "她的真名是艾丝翠特·丽塔尼德·艾斯杰芬比约斯道提尔，这名字不管怎么念都拗口极了。"
         },
         "62012": {
@@ -2493,7 +2493,7 @@
         },
         "62013": {
             "Name": "Kambi",
-            "Info": "Spying.\nDeathwish: Spawn Hemdall.\n(Deploy: Destroy all units and clear all Boons and Hazards.",
+            "Info": "Spying.\nDeathwish: Spawn Hemdall.\n(Hemdall; 20 Strength; Deploy: Destroy all units and clear all Boons and Hazards)",
             "Flavor": "终焉之刻来临时，金公鸡坎比便会叫醒沉睡的汉姆多尔。"
         },
         "63001": {
@@ -2513,7 +2513,7 @@
         },
         "63004": {
             "Name": "Blueboy Lugos",
-            "Info": "Deploy: Spawn a Spectral Whale on an enemy row.\n(On turn end, move to a random row and deal 1 Damage to all units on it)",
+            "Info": "Deploy: Spawn a Spectral Whale on an enemy row.\n(Spectral Whale; 3 Strength; On turn end, move to a random row and deal 1 Damage to all units on it)",
             "Flavor": "我无聊得快吐了。"
         },
         "63005": {
@@ -2553,7 +2553,7 @@
         },
         "63012": {
             "Name": "Harald Houndsnout",
-            "Info": "Deploy: Spawn Wilfred to the left, Wilhelm to the right and Wilmar on the opposite row.",
+            "Info": "Deploy: Spawn Wilfred to the left, Wilhelm to the right and Wilmar on the opposite row.\n(Deathwish: Strengthen a random ally by 3)\n(Deathwish: Damage all units on the opposite row by 1)\n(Deathwish: Spawn an Elder Bear on the opposite row.\n(Elder Bear; 11 Strength)",
             "Flavor": "曾经是托达洛克家族的首领，如今只是一个喋喋不休的疯子。"
         },
         "63013": {
@@ -2658,7 +2658,7 @@
         },
         "64013": {
             "Name": "Svalblod Ravager",
-            "Info": "Whenever this unit is Damaged or Weakened, transform into a Raging Bear.",
+            "Info": "Whenever this unit is Damaged or Weakened, transform into a Raging Bear.\n(Raging Bear; 12 Strength)",
             "Flavor": "在诗人的歌谣里，鏖战中变身的狂战士跟野熊没两样。"
         },
         "64014": {
@@ -2758,7 +2758,7 @@
         },
         "64033": {
             "Name": "Tuirseach Bearmaster",
-            "Info": "Deploy: Spawn an Elder Bear.",
+            "Info": "Deploy: Spawn an Elder Bear.\n(Elder Bear; 11 Strength)",
             "Flavor": "别碰他。别盯着他的眼睛瞧。事实上……压根就别靠近他。"
         },
         "64034": {
@@ -2798,7 +2798,7 @@
         },
         "65007": {
             "Name": "Wilmar",
-            "Info": "Spying.\nDeathwish: Spawn an Elder Bear on the opposite row.",
+            "Info": "Spying.\nDeathwish: Spawn an Elder Bear on the opposite row.\n(Elder Bear; 11 Strength)",
             "Flavor": "高个子的是威尔玛。他右边的是威尔弗雷德。结巴的那个是威尔海姆。"
         },
         "61001": {
@@ -2828,7 +2828,7 @@
         },
         "70002": {
             "Name": "Detlaff: Higher Vampire",
-            "Info": "Deploy, Choose One: Play a Bronze unit from your deck with Power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or Consume a Bronze unit from your deck with more Power than this unit and gain its Power.",
+            "Info": "Deploy, Choose One: Play a Bronze unit from your deck with Power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or Consume a Bronze unit from your deck with more Power than this unit and Boost self by its Power.",
             "Flavor": ""
         },
         "70003": {
@@ -2873,7 +2873,7 @@
         },
         "70011": {
             "Name": "Lady Of The Lake: Advent",
-            "Info": "Spawn Lady Of The Lake. (Deploy: Weaken self by the value equal to twice the number of the remaining cards in your hand and deck)",
+            "Info": "Spawn Lady Of The Lake.\n(Lady of The Lake; 25 Power; Deploy: Weaken self by the value equal to twice the number of the remaining cards in your hand and deck)",
             "Flavor": ""
         },
         "70012": {
@@ -2903,7 +2903,7 @@
         },
         "70017": {
             "Name": "Cintrian Field Medic",
-            "Info": "Deploy: Shuffle a non-identical Bronze ally back to your deck, then play a random Bronze unit from your deck.",
+            "Info": "Deploy: Shuffle a different Bronze ally back to your deck, then play a random Bronze unit from your deck.",
             "Flavor": ""
         },
         "70019": {
@@ -2923,17 +2923,17 @@
         },
         "70022": {
             "Name": "Kikimore Worker",
-            "Info": "Deploy: Choose an Insectoid ally.\nBoost that unit and all copies of it on your side of the board, hand and deck by 2.",
+            "Info": "Deploy: Choose an Insectoid ally.\nBoost that unit and all copies of it in hand, deck and on the board by 2.",
             "Flavor": ""
         },
         "70023": {
             "Name": "Kikimore Warrior",
-            "Info": "Deploy: Consume a non-identical Bronze unit in your deck with current Power no greater than its own, then Boost self by its Power.",
+            "Info": "Deploy: Consume a different Bronze unit in your deck with current Power no greater than its own, then Boost self by its Power.",
             "Flavor": ""
         },
         "70024": {
             "Name": "Cursed Immortals",
-            "Info": "When an adjacent Cursed unit is destroyed, Spawn a Specter on this row.",
+            "Info": "When an adjacent Cursed unit is destroyed, Spawn a Specter on this row.\n(Specter; 5 Strength)",
             "Flavor": ""
         },
         "70025": {
@@ -2953,7 +2953,7 @@
         },
         "70032": {
             "Name": "Gascon",
-            "Info": "Deploy: Move all units to a random other row and Damage self by 2 for each unit moved.\nWhen in your hand or deck, Boost self by 1 whenever a unit moves during your turn.",
+            "Info": "Deploy: Move all enemies to a random row and Damage self by 2 for each unit moved.\nWhen in your hand or deck, Boost self by 1 whenever a unit moves during your turn.",
             "Flavor": "“Th' Strays of Spalla – 'tis you who lead them? 'Tis you they call the Duke of Dogs?”"
         },
         "70033": {
@@ -2968,7 +2968,7 @@
         },
         "70039": {
             "Name": "Dire Wolf Claws",
-            "Info": "Deal 4 Damage to a random enemy.\nWhen Discarded, trigger its ability and add 2 copies of Dire Wolf Warrior in your deck.",
+            "Info": "Deal 4 Damage to a random enemy.\nWhen Discarded, trigger its ability and add 2 Dire Wolf Warriors in your deck.\n(8 Strength; Deploy: Deal 2 Damage to a random enemy. When Discarded, trigger its ability and add a copy of this card to the bottom of your deck)",
             "Flavor": ""
         },
         "70040": {
@@ -2993,7 +2993,7 @@
         },
         "70044": {
             "Name": "Vernossiel",
-            "Info": "Deploy: Add 2 copies of Vernossiel's Commando to your deck and reduce their counter by 1.",
+            "Info": "Deploy: Add 2 Vernossiel's Commandos to your deck and reduce their counter by 1.",
             "Flavor": ""
         },
         "70045": {
@@ -3013,7 +3013,7 @@
         },
         "70054": {
             "Name": "Feign Death",
-            "Info": "Resurrect 2 Bronze units with Power higher than 5, then deal 4 Damage to each of them.",
+            "Info": "Resurrect 2 Bronze units with 6 Power or more, then deal 4 Damage to each of them.",
             "Flavor": ""
         },
         "70058": {
@@ -3023,7 +3023,7 @@
         },
         "70059": {
             "Name": "One-Eyed Betsy",
-            "Info": "At the beginning of the round, Boost self by 3, then Boost the Highest enemy by 3.",
+            "Info": "Every turn, on turn start, Boost self by 3, then Boost the Highest enemy by 3.",
             "Flavor": "准头是差了点，但力道确实没话说。"
         },
         "70062": {
@@ -3033,7 +3033,7 @@
         },
         "70070": {
             "Name": "Highwaymen",
-            "Info": "Single-Use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two copies of Strays of Spalla to your deck.",
+            "Info": "Single-Use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two Strays of Spalla to your deck.\n(Strays of Spalla; 5 Strength; Single-Use; Look at 2 random Bronze units in your deck, then play one)",
             "Flavor": "“商人？抹了。马匹？卖了。”"
         },
         "70071": {
@@ -3043,7 +3043,7 @@
         },
         "70072": {
             "Name": "Radeyah",
-            "Info": "Deploy: Deal Damage equal to the number of neutral cards in your hand.",
+            "Info": "Deploy: Deal Damage equal to the number of Neutral cards in your hand.",
             "Flavor": "“迷人的微笑背后可以潜藏许多秘密……”"
         },
         "70076": {
@@ -3063,7 +3063,7 @@
         },
         "70091": {
             "Name": "Magic Lamp",
-            "Info": "At the start of the game, add 3 copies of The Last Wish to your deck, then Discard self.",
+            "Info": "At the start of the game, add 3 The Last Wishes to your deck, then Discard self.",
             "Flavor": "破译梦境中的过去和未来是非常困难的，即使对大师也是如此。"
         },
         "70102": {
@@ -3088,12 +3088,12 @@
         },
         "70106": {
             "Name": "Endrega Eggs",
-            "Info": "Deploy: Spawn 1 base copy of this card on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of the turn, destroy self.",
+            "Info": "Deploy: Spawn 1 base copy of this card on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of the turn, destroy self.\n(5 Strength; After 3 turns, at the end of the turn, transform into an Endrega Warrior)\n(Endrega Warrior; 7 Strength)",
             "Flavor": "If you find some it's best to burn the entire forest down. Then run as far away as you can."
         },
         "70107": {
             "Name": "Endrega Larva",
-            "Info": "After 3 turns, at the end of the turn, transform into Endrega Warrior.",
+            "Info": "After 3 turns, at the end of the turn, transform into an Endrega Warrior.",
             "Flavor": "Fat, plump… and bloodthirsty."
         },
         "70108": {
@@ -3113,7 +3113,7 @@
         },
         "130220": {
             "Name": "Prize-Winning Cow: Promoted",
-            "Info": "Deathwish: Spawn a Chort, then deal 2 Damage to all emenies on the same row.",
+            "Info": "Deathwish: Spawn a Chort, then deal 2 Damage to all emenies on the same row.\n(Chort; 14 Strength)",
             "Flavor": "哞～～～"
         },
         "130200": {
@@ -3167,8 +3167,8 @@
             "Flavor": "这样的沟通方式才对路嘛！"
         },
         "130110": {
-            "Name": "Carlo Varese",
-            "Info": "Deal 9 Damage.\nDeal overflowed damge to adjacent cards.",
+            "Name": "Carlo Varese: Promoted",
+            "Info": "Deal 9 Damage.\nDeal overflowed damage to adjacent cards.",
             "Flavor": "每个想要在诺维格瑞做生意的都很清楚——要么同意卡罗的条件，要么就夹着尾巴滚出去。"
         },
         "130090": {
@@ -3193,7 +3193,7 @@
         },
         "130050": {
             "Name": "Germain Piquant: Promoted",
-            "Info": "Deploy: Spawn 3 Cows on each side of this unit.",
+            "Info": "Deploy: Spawn 3 Cows on each side of this unit.\n(Cow; 1 Strength)",
             "Flavor": "陶森特需要这位英雄，但它不配。"
         },
         "130060": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -229,15 +229,15 @@
         "ShupeKnight_3_Duel": "Duel an enemy. ",
         "ShupeKnight_4_Reset": "Reset a unit.",
         "ShupeKnight_5_Destroy": "Destroy enemies with less than 4 power.",
-        "ShupeHunter_1_SingleDamage": "Deal 15 damage.",
-        "ShupeHunter_2_RepeatedDamage": "Deal 2 damage to a random enemy. Repeat 8 times.",
+        "ShupeHunter_1_SingleDamage": "Deal 15 Damage.",
+        "ShupeHunter_2_RepeatedDamage": "Deal 2 Damage to a random enemy. Repeat 8 times.",
         "ShupeHunter_3_Replay": "Replay a Bronze or Silver ally and boost it by 5.",
         "ShupeHunter_4_PlayFromDeck": "Play a Bronze or Silver unit from your deck",
         "ShupeHunter_5_ClearSky": " Clear all Hazards from your side and boost allies by 1.",
         "ShupeMage_1_DrawCard": "Draw a card.",
         "ShupeMage_2_Charm": "Charm a random enemy.",
         "ShupeMage_3_Hazard": "Spawn random Hazards on all enemy rows.",
-        "ShupeMage_4_Damage": "Deal 10 damage to an enemy and 5 to any adjacent to it.",
+        "ShupeMage_4_Damage": "Deal 10 Damage to an enemy and 5 to any adjacent to it.",
         "ShupeMage_5_Special": "Play a Bronze or Silver special card from your deck."
     },
     "CardLocales": {
@@ -258,22 +258,22 @@
         },
         "12007": {
             "Name": "Triss Merigold",
-            "Info": "Deploy: Deal 5 damage.",
+            "Info": "Deploy: Deal 5 Damage.",
             "Flavor": "I can take care of myself. Trust me."
         },
         "12008": {
             "Name": "Villentretenmerth",
-            "Info": "After 3 turns, on turn start, destroy the Highest units, excluding self. 3 Armor.",
+            "Info": "After 3 turns, on turn start, destroy the Highest units, excluding self.\n3 Armor.",
             "Flavor": "Also calls himself Borkh Three Jackdaws… he's not the best at names."
         },
         "12009": {
             "Name": "Ale of the Ancestors",
-            "Info": "Deploy: Apply Golden Froth to the row. Repeat this ability when moved, then deal 4 damage to self.",
+            "Info": "Deploy: Apply Golden Froth to the row. Repeat this ability when moved, then deal 4 Damage to self.",
             "Flavor": "Boros, the legendary founder of Clan Fuchs, died after overindulging in this beverage - he passed out while reaching for his golden ring, which had fallen into a brook."
         },
         "12010": {
             "Name": "Yennefer: Conjurer",
-            "Info": "On turn end, deal 1 damage to the Highest enemies.",
+            "Info": "On turn end, deal 1 Damage to the Highest enemies.",
             "Flavor": "A good sorceress must know when to conjure ice... and when to conjure fire."
         },
         "12011": {
@@ -288,7 +288,7 @@
         },
         "12013": {
             "Name": "Lambert: Swordmaster",
-            "Info": "Deploy: Deal 4 damage to all copies of an enemy unit.",
+            "Info": "Deploy: Deal 4 Damage to all copies of an enemy unit.",
             "Flavor": "Go teach your grandma to suck eggs."
         },
         "12014": {
@@ -298,7 +298,7 @@
         },
         "12015": {
             "Name": "Zoltan: Scoundrel",
-            "Info": "Deploy, Choose One: Spawn a Duda: Companion that boosts 2 units on each side of it by 2; or Spawn a Duda: Agitator that deals 2 damage to 2 units on each side of it.",
+            "Info": "Deploy, Choose One: Spawn a Duda: Companion that boosts 2 units on each side of it by 2; or Spawn a Duda: Agitator that deals 2 Damage to 2 units on each side of it.",
             "Flavor": "Apologies. My exotic pet's a clever birdie, but a wee bit lewd. Paid ten thalers for the beaute."
         },
         "12016": {
@@ -308,17 +308,17 @@
         },
         "12017": {
             "Name": "Geralt: Professional",
-            "Info": "Deploy: Deal 4 damage to an enemy unit.\nIf it's a Monster unit, destroy it instead.",
+            "Info": "Deploy: Deal 4 Damage to an enemy unit.\nIf it's a Monster unit, destroy it instead.",
             "Flavor": "I accepted a job once, did it. Asked to choose my reward, I invoked the Law of Surprise."
         },
         "12018": {
             "Name": "Ihuarraquax",
-            "Info": "Deploy: Deal 5 damage to self.\nThe first time this unit's current power is equal to its base power, on turn end, deal 7 damage to 3 random enemy units.",
+            "Info": "Deploy: Deal 5 Damage to self.\nThe first time this unit's current power is equal to its base power, on turn end, deal 7 Damage to 3 random enemy units.",
             "Flavor": "\"Inconceivable. Impossible\", Ciri thought, returning to her senses. \"Unicorns don't exist, not any more, not in this world. Unicorns are extinct.\" "
         },
         "12019": {
             "Name": "Ciri",
-            "Info": "Whenever you lose a round, return this unit to your hand. 2 Armor.",
+            "Info": "Whenever you lose a round, return this unit to your hand.\n2 Armor.",
             "Flavor": "I go wherever I please, whenever I please"
         },
         "12020": {
@@ -328,7 +328,7 @@
         },
         "12021": {
             "Name": "Geralt: Aard",
-            "Info": "Deploy: Deal 3 damage to 3 enemies and move them to the row above.",
+            "Info": "Deploy: Deal 3 Damage to 3 enemies and move them to the row above.",
             "Flavor": "A blast of concentrated energy that pummels everything in its path. Great for when you forget your keys."
         },
         "12022": {
@@ -343,7 +343,7 @@
         },
         "12024": {
             "Name": "Yennefer",
-            "Info": "Deploy, Choose One: Spawn a Unicorn that boosts all other units by 2; or Spawn a Chironex that deals 2 damage to all other units.",
+            "Info": "Deploy, Choose One: Spawn a Unicorn that boosts all other units by 2; or Spawn a Chironex that deals 2 Damage to all other units.",
             "Flavor": "Magic is Chaos, Art and Science. It is a curse, a blessing and a progression."
         },
         "12025": {
@@ -353,17 +353,17 @@
         },
         "12026": {
             "Name": "Triss: Telekinesis",
-            "Info": "Deploy: Create and play a Bronze Special card from either player's starting deck.",
+            "Info": "Deploy: Create and play a Bronze special card from either player's starting deck.",
             "Flavor": "Bindings won't suffice. Nor will a gag render her any less dangerous. No, dimeritium is the only solution."
         },
         "12002": {
             "Name": "Geralt: Igni",
-            "Info": "Deploy: Destroy the Highest units on an enemy row if that row has a total of 25 points or more.",
+            "Info": "Deploy: Destroy the Highest units on an enemy row if that row has a total of 25 or more.",
             "Flavor": "A twist of a witcher's fingers can light a lamp… or incinerate a foe."
         },
         "12027": {
             "Name": "Aguara",
-            "Info": "Deploy, Choose Two: Boost the Lowest ally by 5; Boost a random unit in your hand by 5; Deal 5 damage to the Highest enemy; Charm a random enemy Elf with 5 power or less.",
+            "Info": "Deploy, Choose Two: Boost the Lowest ally by 5; Boost a random unit in your hand by 5; Deal 5 Damage to the Highest enemy; Charm a random enemy Elf with 5 power or less.",
             "Flavor": "Smarten up right now, or it's off to an aguara with you!"
         },
         "12028": {
@@ -398,12 +398,12 @@
         },
         "12033": {
             "Name": "Korathi Heatwave",
-            "Info": "Apply a Hazard to each enemy row that deals 2 damage to the Lowest unit on turn start.",
+            "Info": "Apply a Hazard to each enemy row that deals 2 Damage to the Lowest unit on turn start.",
             "Flavor": "Vicovaro scholars have determined that, in the absence of imperial aid, drought-stricken provinces lose half their population, two-thirds of their livestock and all their will to rebel."
         },
         "12034": {
             "Name": "Ragh Nar Roog",
-            "Info": "Apply a Hazard to each enemy row that deals 2 damage to the Highest unit on turn start.",
+            "Info": "Apply a Hazard to each enemy row that deals 2 Damage to the Highest unit on turn start.",
             "Flavor": "In the Final Age, Hemdall will come forth to face the evil issuing from the land of Morhogg – the legions of wraiths, demons and specters of Chaos"
         },
         "12035": {
@@ -423,7 +423,7 @@
         },
         "12037": {
             "Name": "Wolfsbane",
-            "Info": "After 3 turns in the graveyard, on turn end, deal 6 damage to the Highest enemy and boost the Lowest ally by 6.",
+            "Info": "After 3 turns in the graveyard, on turn end, deal 6 Damage to the Highest enemy and boost the Lowest ally by 6.",
             "Flavor": "Also known as 'the queen of poisons,' wolfsbane is used in many witcher Potions and alchemic brews."
         },
         "12038": {
@@ -438,7 +438,7 @@
         },
         "12040": {
             "Name": "Trial of the Grasses",
-            "Info": "Deal 10 damage to a unit, unless it's a Witcher.\nIf it survives, boost it to 25 power.",
+            "Info": "Deal 10 Damage to a unit, unless it's a Witcher.\nIf it survives, boost it to 25 power.",
             "Flavor": "Imagine a lump of clay. In order to shape it, you must first moisten it or it will crumble. The Trial's initial part does just that. It opens the body to change, so to speak. Only then can the mutagens produce a witcher."
         },
         "12041": {
@@ -448,7 +448,7 @@
         },
         "12042": {
             "Name": "Sihil",
-            "Info": "Choose One: Deal 3 damage to all enemies with odd power; or Deal 3 damage to all enemies with even power; or Play a random Bronze or Silver unit from your deck.",
+            "Info": "Choose One: Deal 3 Damage to all enemies with odd power; or Deal 3 Damage to all enemies with even power; or Play a random Bronze or Silver unit from your deck.",
             "Flavor": "\"What's written on this blade? That a curse?\" \"No. An insult.\" "
         },
         "13003": {
@@ -458,7 +458,7 @@
         },
         "13004": {
             "Name": "Iris' Companions",
-            "Info": "Deploy: Move a card from your deck to your hand, then discard a random card.",
+            "Info": "Deploy: Move a card from your deck to your hand, then Discard a random card.",
             "Flavor": "我们的名字还是不说为好。就当我们是……主人家的朋友吧。"
         },
         "13005": {
@@ -488,12 +488,12 @@
         },
         "13010": {
             "Name": "Ocvist",
-            "Info": "Single-Use.\nAfter 4 turns, on turn start, deal 1 damage to all enemies, then return to your hand.",
+            "Info": "Single-Use.\nAfter 4 turns, on turn start, deal 1 Damage to all enemies, then return to your hand.",
             "Flavor": "他是石英山之主，毁灭者，图拉真的屠夫。但在闲暇时间里，他喜欢远足和烛光晚餐。"
         },
         "13011": {
             "Name": "Carlo Varese",
-            "Info": "Deploy: Deal 1 damage for each card in your hand.",
+            "Info": "Deploy: Deal 1 Damage for each card in your hand.",
             "Flavor": "每个想要在诺维格瑞做生意的都很清楚——要么同意卡罗的条件，要么就夹着尾巴滚出去。"
         },
         "13012": {
@@ -623,7 +623,7 @@
         },
         "13035": {
             "Name": "Skellige Storm",
-            "Info": "Apply a Hazard to an enemy row that deals 2, 1 and 1 damage to the leftmost units on the row on turn start.",
+            "Info": "Apply a Hazard to an enemy row that deals 2, 1 and 1 Damage to the leftmost units on the row on turn start.",
             "Flavor": "这可不是普通风暴，这是天神之怒。"
         },
         "13036": {
@@ -638,22 +638,22 @@
         },
         "13038": {
             "Name": "White Frost",
-            "Info": "Apply Biting Frost to 2 adjacent enemy rows. Biting Frost: Every turn, on turn start, damage the Lowest unit on the row by 2.",
+            "Info": "Apply Biting Frost to 2 adjacent enemy rows. Biting Frost: Every turn, on turn start, Damage the Lowest unit on the row by 2.",
             "Flavor": "见证“泰德戴尔瑞”——终焉纪元——这被白霜摧毀的世界吧！"
         },
         "13039": {
             "Name": "Tainted Ale",
-            "Info": "Deal 6 damage to the Highest enemy on each row.",
+            "Info": "Deal 6 Damage to the Highest enemy on each row.",
             "Flavor": "这酒原本就是绿色的吗……？"
         },
         "13040": {
             "Name": "Mandrake",
-            "Info": "Choose One: Heal a unit and strengthen it by 6; or reset a unit and weaken it by 6.",
+            "Info": "Choose One: Heal a unit and strengthen it by 6; or Reset a unit and Weaken it by 6.",
             "Flavor": "衮衮诸公，瞠目环立，不肯相信这高贵的发现。有的在谈曼陀罗花，有的又说是在用黑犬。"
         },
         "13041": {
             "Name": "Bekker's Rockslide",
-            "Info": "Deal 2 damage to up to 10 random enemies.",
+            "Info": "Deal 2 Damage to up to 10 random enemies.",
             "Flavor": "只要一块小石子，我们就完蛋了。"
         },
         "13042": {
@@ -663,7 +663,7 @@
         },
         "13043": {
             "Name": "Dragon's Dream",
-            "Info": "Apply a Hazard to an enemy row that will explode and deal 4 damage to all units when a different Special card is played.",
+            "Info": "Apply a Hazard to an enemy row that will explode and deal 4 Damage to all units when a different special card is played.",
             "Flavor": "在瑟瑞卡尼亚，龙神崇拜体现在日常生活的各个方面。因此也难怪他们会以此为武器命名了。"
         },
         "13044": {
@@ -678,7 +678,7 @@
         },
         "14003": {
             "Name": "Alzur's Thunder",
-            "Info": "Deal 9 damage to a unit.",
+            "Info": "Deal 9 Damage to a unit.",
             "Flavor": "我们全然无法念诵“阿尔祖落雷术”这样深奥复杂的咒语。据说，阿尔祖声如狩猎号角，言若讲演名家。"
         },
         "14004": {
@@ -688,7 +688,7 @@
         },
         "14005": {
             "Name": "Biting Frost",
-            "Info": "Apply a Hazard to an enemy row that deals 2 damage to the Lowest unit on turn start.",
+            "Info": "Apply a Hazard to an enemy row that deals 2 Damage to the Lowest unit on turn start.",
             "Flavor": "寒霜凛冽的好处就是尸体不会腐烂得那么快。"
         },
         "14006": {
@@ -698,7 +698,7 @@
         },
         "14007": {
             "Name": "Dimeritium Shackles",
-            "Info": "Toggle a unit's Lock status.\nIf an enemy, deal 5 damage to it.",
+            "Info": "Toggle a unit's Lock status.\nIf an enemy, deal 5 Damage to it.",
             "Flavor": "The mage's arms were twisted and bound behind his back. The Redanians gave the fetters a good shake. Terranova cried out, lurched, bent backwards, bowed forward, then retched and groaned. It was clear of what his manacles were made."
         },
         "14008": {
@@ -708,7 +708,7 @@
         },
         "14009": {
             "Name": "Clear Skies",
-            "Info": "Choose One: Boost all damaged allies under Hazards by 2 and clear all Hazards from your side; or Play a random Bronze unit from your deck.",
+            "Info": "Choose One: Boost all Damaged allies under Hazards by 2 and clear all Hazards from your side; or Play a random Bronze unit from your deck.",
             "Flavor": "太阳出来了，德洛米！太阳出来了！也许我们命不该绝……"
         },
         "14010": {
@@ -718,7 +718,7 @@
         },
         "14011": {
             "Name": "Impenetrable Fog",
-            "Info": "Apply a Hazard to an enemy row that deals 2 damage to the Highest unit on turn start.",
+            "Info": "Apply a Hazard to an enemy row that deals 2 Damage to the Highest unit on turn start.",
             "Flavor": "优秀指挥官的福音……拙劣指挥官的噩梦。"
         },
         "14012": {
@@ -728,7 +728,7 @@
         },
         "14013": {
             "Name": "Mardroeme",
-            "Info": "Choose One: Reset a unit and strengthen it by 3; or reset a unit and weaken it by 3.",
+            "Info": "Choose One: Reset a unit and strengthen it by 3; or Reset a unit and Weaken it by 3.",
             "Flavor": "Carried by the wind across the Continent… Sowing madness and blight where they fall."
         },
         "14014": {
@@ -743,7 +743,7 @@
         },
         "14016": {
             "Name": "Stammelford's Tremors",
-            "Info": "Deal 1 damage to all enemies.",
+            "Info": "Deal 1 Damage to all enemies.",
             "Flavor": "巫师斯丹莫福德曾将一座挡住他高塔视线的大山移走。传言他有这等移山之力，全因得到了一只地灵——也就是土界灵——的服务。"
         },
         "14017": {
@@ -758,7 +758,7 @@
         },
         "14019": {
             "Name": "Torrential Rain",
-            "Info": "Apply a Hazard to an enemy row that deals 1 damage to both the Highest and Lowest unit on turn start.",
+            "Info": "Apply a Hazard to an enemy row that deals 1 Damage to both the Highest and Lowest unit on turn start.",
             "Flavor": "这儿连雨都带股尿骚味。"
         },
         "14020": {
@@ -768,7 +768,7 @@
         },
         "14021": {
             "Name": "Crow's Eye",
-            "Info": "Deal 4 damage to the Highest enemy on each row. Deal 1 extra damage for each copy of this card in your graveyard.",
+            "Info": "Deal 4 Damage to the Highest enemy on each row. Deal 1 extra Damage for each copy of this card in your graveyard.",
             "Flavor": "某个大名鼎鼎的海盗曾经沉迷于这种迷人的药草，进而得名“乌鸦眼”。然而对于海盗故事十分讲究的人而言，他的这一段传说实在太不像话，自然也就没能流传下来。"
         },
         "14022": {
@@ -778,12 +778,12 @@
         },
         "14023": {
             "Name": "Rock Barrage",
-            "Info": "Deal 7 damage to an enemy and move it to the row above.\nIf the row is full, destroy the enemy instead.",
+            "Info": "Deal 7 Damage to an enemy and move it to the row above.\nIf the row is full, destroy the enemy instead.",
             "Flavor": "有一天等你老了，也会难逃被石头砸中的厄运。"
         },
         "14024": {
             "Name": "Mastercrafted Spear",
-            "Info": "Deal damage equal to the base power of a Bronze or Silver unit in your hand.",
+            "Info": "Deal Damage equal to the base power of a Bronze or Silver unit in your hand.",
             "Flavor": "把长矛立起来，懒虫！一匹马都不能放过去！"
         },
         "14001": {
@@ -793,7 +793,7 @@
         },
         "14025": {
             "Name": "Spores",
-            "Info": "Deal 2 damage to all units on a row and clear a Boon from it.",
+            "Info": "Deal 2 Damage to all units on a row and clear a Boon from it.",
             "Flavor": "吃够量，世界就会变个样……"
         },
         "14026": {
@@ -808,17 +808,17 @@
         },
         "15001": {
             "Name": "Shupe: Knight",
-            "Info": "Send Shupe to the Imperial Court Military Academy. Strengthen self to 25; Gain resilience; Duel a unit; Reset a unit; Destroy all enemies with 4 power or less.",
+            "Info": "Send Shupe to the Imperial Court Military Academy. Strengthen self to 25; Gain Resilience; Duel a unit; Reset a unit; Destroy all enemies with 4 power or less.",
             "Flavor": "其他巨魔都觉得他是个异类，毕竟在巨魔们看来，谁会喜欢彩色纸片胜过喜欢石头呢？"
         },
         "15002": {
             "Name": "Shupe: Hunter",
-            "Info": "Send Shupe to the forests of Dol Blathanna. Deal 15 damage; Deal 2 damage to a random enemy 8 times; Replay a Bronze or Silver unit and boost it by 5; Play a Bronze or Silver unit from your deck; Remove Hazards on your side of the board and boost your units by 1.",
+            "Info": "Send Shupe to the forests of Dol Blathanna. Deal 15 Damage; Deal 2 Damage to a random enemy 8 times; Replay a Bronze or Silver unit and boost it by 5; Play a Bronze or Silver unit from your deck; Remove Hazards on your side of the board and boost your units by 1.",
             "Flavor": "其他巨魔都觉得他是个异类，毕竟在巨魔们看来，谁会喜欢彩色纸片胜过喜欢石头呢？"
         },
         "15003": {
             "Name": "Shupe: Mage",
-            "Info": "Send Shupe to the Ban Ard Academy. Draw 1 card; Charm a random enemy unit; Spawn a random Hazard on all enemy rows; Deal 10 damage to an enemy, then 5 damage to adjacent units; Play a special card from your deck.",
+            "Info": "Send Shupe to the Ban Ard Academy. Draw 1 card; Charm a random enemy unit; Spawn a random Hazard on all enemy rows; Deal 10 Damage to an enemy, then 5 Damage to adjacent units; Play a special card from your deck.",
             "Flavor": "其他巨魔都觉得他是个异类，毕竟在巨魔们看来，谁会喜欢彩色纸片胜过喜欢石头呢？"
         },
         "15004": {
@@ -833,7 +833,7 @@
         },
         "15006": {
             "Name": "Duda: Agitator",
-            "Info": "Deploy: Deal 2 damage to 2 units on each side of this card.",
+            "Info": "Deploy: Deal 2 Damage to 2 units on each side of this card.",
             "Flavor": "卓尔坦的鹦鹉拥有一项超凡能力：能逼疯所有与它相处的人，包括卓尔坦本人。"
         },
         "15007": {
@@ -868,7 +868,7 @@
         },
         "15013": {
             "Name": "Clear Skies",
-            "Info": "Boost all damaged allies under Hazards by 2 and clear all Hazards from your side.",
+            "Info": "Boost all Damaged allies under Hazards by 2 and clear all Hazards from your side.",
             "Flavor": "太阳出来了，德洛米！太阳出来了！也许我们命不该绝……"
         },
         "15014": {
@@ -913,7 +913,7 @@
         },
         "22003": {
             "Name": "Old Speartip",
-            "Info": "Deploy: Deal 2 damage to up to 5 enemies on the opposite row.",
+            "Info": "Deploy: Deal 2 Damage to up to 5 enemies on the opposite row.",
             "Flavor": "哦，你现在可有大麻烦了......"
         },
         "22004": {
@@ -943,7 +943,7 @@
         },
         "22009": {
             "Name": "Imlerith: Sabbath",
-            "Info": "Every turn, on turn end, duel the Highest enemy.\nIf this unit survives, heal it by 2 and give it 2 Armor.\nRepeat up to 2 times.\n2 Armor.",
+            "Info": "Every turn, on turn end, Duel the Highest enemy.\nIf this unit survives, Heal it by 2 and give it 2 Armor.\nRepeat up to 2 times.\n2 Armor.",
             "Flavor": "老巫妪说过你会来。她们在水面上预见了你的到来。"
         },
         "22010": {
@@ -963,7 +963,7 @@
         },
         "22013": {
             "Name": "Ge'els",
-            "Info": "Deploy: Draw the top Gold card and top Silver card from your Deck.\nPlay one and return the other to the top of your Deck. ",
+            "Info": "Deploy: Draw the top Gold card and top Silver card from your deck.\nPlay one and return the other to the top of your deck. ",
             "Flavor": "画作传情，而非言词。"
         },
         "22014": {
@@ -983,7 +983,7 @@
         },
         "23003": {
             "Name": "Golyat",
-            "Info": "Deploy: Boost self by 7.\nWhenever this unit is damaged, deal 2 damage to self.",
+            "Info": "Deploy: Boost self by 7.\nWhenever this unit is Damaged, deal 2 Damage to self.",
             "Flavor": "据说哥亚特曾经是一位闻名遐迩的骑士。只可惜，有一天他触怒了湖中仙女，被变成了一头怪物。"
         },
         "23004": {
@@ -1013,7 +1013,7 @@
         },
         "23009": {
             "Name": "Jotunn",
-            "Info": "Deploy: Move 3 enemies to this row on their side and damage them by 2.\nIf that row is affected by Biting Frost, damage them by 3 instead.",
+            "Info": "Deploy: Move 3 enemies to this row on their side and Damage them by 2.\nIf that row is affected by Biting Frost, Damage them by 3 instead.",
             "Flavor": "在史凯利格的传说中，强大而恐怖的巨人之王约顿是群岛在上古时期的统治者。他最终死于汉姆多尔的剑下，但在弥留之际，他发誓要在终末之战时重返人间。"
         },
         "23010": {
@@ -1023,17 +1023,17 @@
         },
         "23011": {
             "Name": "Nithral",
-            "Info": "Deploy: Deal 6 damage to an enemy.\nIncrease damage by 1 for each Wild Hunt unit in your hand.",
+            "Info": "Deploy: Deal 6 Damage to an enemy.\nIncrease Damage by 1 for each Wild Hunt unit in your hand.",
             "Flavor": "每个狂猎战士都要经过严格筛选，而只有最残暴、最凶狠的那些才能加入艾瑞汀的骑兵队。"
         },
         "23012": {
             "Name": "Toad Prince",
-            "Info": "Deploy: Draw a unit, then consume a unit in your hand and boost self by its power.",
+            "Info": "Deploy: Draw a unit, then Consume a unit in your hand and boost self by its power.",
             "Flavor": "又大又坏又丑，住在下水道里。"
         },
         "23013": {
             "Name": "Adda: Striga",
-            "Info": "Deploy: Deal 8 damage to a non-Monster unit.",
+            "Info": "Deploy: Deal 8 Damage to a non-Monster unit.",
             "Flavor": "吸血妖鸟挺好的。当然，她会时不时地在谁的身上咬一口，但我们早就习惯了。"
         },
         "23014": {
@@ -1058,12 +1058,12 @@
         },
         "23018": {
             "Name": "Maerolorn",
-            "Info": "Deploy: Play a Bronze Deathwish unit from your Deck.",
+            "Info": "Deploy: Play a Bronze Deathwish unit from your deck.",
             "Flavor": "别怕阴影，该怕的是亮光。"
         },
         "23019": {
             "Name": "She-Troll of Vergen",
-            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, consume it and boost self by its base power",
+            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, Consume it and boost self by its base power",
             "Flavor": "着迷于精灵洋葱汤。"
         },
         "23020": {
@@ -1078,12 +1078,12 @@
         },
         "23022": {
             "Name": "Parasite",
-            "Info": "Choose One: Deal 12 damage to an enemy; or boost an ally by 12.",
+            "Info": "Choose One: Deal 12 Damage to an enemy; or boost an ally by 12.",
             "Flavor": "确实引人注目。"
         },
         "24001": {
             "Name": "Cyclops",
-            "Info": "Deploy: Destroy an ally and deal its power as damage.",
+            "Info": "Deploy: Destroy an ally and deal its power as Damage.",
             "Flavor": "别盯着它的眼睛，他不喜欢那样……"
         },
         "24002": {
@@ -1103,7 +1103,7 @@
         },
         "24005": {
             "Name": "Wild Hunt Rider",
-            "Info": "Increase the damage dealt by Biting Frost on the opposite row by 1.",
+            "Info": "Increase the Damage dealt by Biting Frost on the opposite row by 1.",
             "Flavor": "首先映入眼帘的是头盔旁的两只水牛角，接着是牛角间的头冠，最后是面甲下白骨般的脸。"
         },
         "24006": {
@@ -1128,7 +1128,7 @@
         },
         "24010": {
             "Name": "Arachas Behemoth",
-            "Info": "Whenever you consume a unit, Spawn an Arachas Hatchling.\nRepeat up to 3 times.",
+            "Info": "Whenever you Consume a unit, Spawn an Arachas Hatchling.\nRepeat up to 3 times.",
             "Flavor": "看起来像螃蟹和蜘蛛的杂交……只是体型硕大无比。"
         },
         "24011": {
@@ -1143,12 +1143,12 @@
         },
         "24013": {
             "Name": "Archespore",
-            "Info": "On turn start, move to a random row and deal 1 damage to a random enemy.\nDeathwish: Deal 4 damage to a random enemy.",
+            "Info": "On turn start, move to a random row and deal 1 Damage to a random enemy.\nDeathwish: Deal 4 Damage to a random enemy.",
             "Flavor": "根据民间传说，它们会在亡者鲜血的浇灌下破土而出。因此在拥有黑暗过往的地方，它们长得特别茂盛。"
         },
         "24014": {
             "Name": "Drowner",
-            "Info": "Deploy: Move an enemy to the opposite row and deal 2 damage to it.\nIf that row is under a Hazard, deal 4 damage instead.",
+            "Info": "Deploy: Move an enemy to the opposite row and deal 2 Damage to it.\nIf that row is under a Hazard, deal 4 Damage instead.",
             "Flavor": "尽管猎魔人想多赚些金币，但杀水鬼这活儿只值一枚银币，或者三个铜板——不能再多了。"
         },
         "24015": {
@@ -1158,7 +1158,7 @@
         },
         "24016": {
             "Name": "Wild Hunt Warrior",
-            "Info": "Deploy: Deal 4 damage to an enemy.\nIf the enemy is destroyed or is under Biting Frost, boost self by 2.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf the enemy is destroyed or is under Biting Frost, boost self by 2.",
             "Flavor": "白霜将至。"
         },
         "24017": {
@@ -1183,22 +1183,22 @@
         },
         "24021": {
             "Name": "Ice Giant",
-            "Info": "Deploy: For every Biting Frost on the board, boost self by 3 points. Every time a Biting Frost appears on the board, boost self by 3 points.",
+            "Info": "Deploy: For every Biting Frost on the board, boost self by 3. Every time a Biting Frost appears on the board, boost self by 3.",
             "Flavor": "我这辈子只当过一次逃兵，就是碰上寒冰巨人那次——我一点也没觉得丢人。"
         },
         "24022": {
             "Name": "Vran Warrior",
-            "Info": "Deploy: Consume the unit to the right and boost self by its power.\nEvery 2 turns, on turn start, repeat its deploy ability.",
+            "Info": "Deploy: Consume the unit to the right and boost self by its power.\nEvery 2 turns, on turn start, repeat its ability.",
             "Flavor": "他们静静地骑在马上，看起来很放松，但全副武装：宽头短矛、剑柄独特的剑、战斧以及锯齿长斧。"
         },
         "24023": {
             "Name": "Wyvern",
-            "Info": "Deploy: Deal 5 damage to an enemy.",
+            "Info": "Deploy: Deal 5 Damage to an enemy.",
             "Flavor": "想象一下在最可怕的噩梦中出现的长翅膀的蛇——翼手龙比这更可怕。"
         },
         "24024": {
             "Name": "Lamia",
-            "Info": "Deploy: Deal 4 damage to an enemy.\nIf the enemy is under Blood Moon, deal 7 damage instead.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf the enemy is under Blood Moon, deal 7 Damage instead.",
             "Flavor": "有个迷信的家伙用蜡堵住耳朵，结果什么也听不到，包括警告——他的船直接撞上了礁石。"
         },
         "24025": {
@@ -1213,7 +1213,7 @@
         },
         "24027": {
             "Name": "Werecat",
-            "Info": "Deploy: Deal 5 damage to an enemy, then deal 1 damage to all enemies under Blood Moon.",
+            "Info": "Deploy: Deal 5 Damage to an enemy, then deal 1 Damage to all enemies under Blood Moon.",
             "Flavor": "他不喜欢你挠他的肚子。"
         },
         "24028": {
@@ -1233,12 +1233,12 @@
         },
         "24031": {
             "Name": "Nekker",
-            "Info": "Whenever you consume a card, boost this unit by 1 if in hand, deck or on board.\nDeathwish: Play a copy of this unit from your deck.",
+            "Info": "Whenever you Consume a card, boost this unit by 1 if in hand, deck or on board.\nDeathwish: Play a copy of this unit from your deck.",
             "Flavor": "如果忽略它们会攻击人类的残酷事实，这些小家伙其实挺可爱的。"
         },
         "24032": {
             "Name": "Wild Hunt Hound",
-            "Info": "Deploy: Play Biting Frost from your Deck.",
+            "Info": "Deploy: Play Biting Frost from your deck.",
             "Flavor": "下令出动，放狗开战。"
         },
         "24033": {
@@ -1248,7 +1248,7 @@
         },
         "24034": {
             "Name": "Ice Troll",
-            "Info": "Deploy: Duel an enemy.\nIf the enemy is under Biting Frost, deal double damage.",
+            "Info": "Deploy: Duel an enemy.\nIf the enemy is under Biting Frost, deal double Damage.",
             "Flavor": "巨魔形形色色，身材、嗜好各有不同。不过它们的脑子都和一桶锈钉子差不了多少。"
         },
         "24035": {
@@ -1288,7 +1288,7 @@
         },
         "25004": {
             "Name": "Harpy Egg",
-            "Info": "When consumed by another unit, boost that unit by an additional 5 points.\nDeathwish: Spawn a Harpy Hatchling on a random row.",
+            "Info": "When Consumed by another unit, boost that unit by an additional 5.\nDeathwish: Spawn a Harpy Hatchling on a random row.",
             "Flavor": "鹰身女妖蛋卷，真是美味佳肴啊，好先生。但它也非常昂贵，您可能料得到，这些可怜的鸟儿并不愿跟自己的蛋分离。"
         },
         "25005": {
@@ -1298,7 +1298,7 @@
         },
         "25006": {
             "Name": "Lesser Ifrit",
-            "Info": "When summoned deal 1 damage to a random enemy",
+            "Info": "When Summoned, deal 1 Damage to a random enemy",
             "Flavor": "曾经有个法师觉得它们可爱，而他的命运催生了一句俗语：“不要玩火自焚。”"
         },
         "25007": {
@@ -1308,7 +1308,7 @@
         },
         "25008": {
             "Name": "Blood Moon",
-            "Info": "Apply a Hazard to an enemy row that deals 2 damage to all units on contact.",
+            "Info": "Apply a Hazard to an enemy row that deals 2 Damage to all units on contact.",
             "Flavor": "满月的时候，梦魇便会从世界的各个角落匍匐而出。"
         },
         "25009": {
@@ -1343,7 +1343,7 @@
         },
         "32003": {
             "Name": "Vattier de Rideaux",
-            "Info": "Deploy: reveal up to 2 of your cards, then reveal the same number of your opponent's randomly.",
+            "Info": "Deploy: Reveal up to 2 of your cards, then Reveal the same number of your opponent's randomly.",
             "Flavor": "精心策划的暗算能解决所有麻烦。"
         },
         "32004": {
@@ -1353,12 +1353,12 @@
         },
         "32005": {
             "Name": "Tibor Eggebracht",
-            "Info": "Deploy, Truce: Boost self by 15, then your opponent draws a revealed Bronze card.",
+            "Info": "Deploy, Truce: Boost self by 15, then your opponent draws a Revealed Bronze card.",
             "Flavor": "蒂博尔以狂热的忠诚而闻名。据说皇帝驾崩时，他深深地鞠躬致敬，几乎可以说贴在了地上。"
         },
         "32006": {
             "Name": "Vilgefortz",
-            "Info": "Deploy: Destroy an ally, then play a card from your deck; or Truce: Destroy an enemy, then your opponent draws a revealed Bronze card.",
+            "Info": "Deploy: Destroy an ally, then play a card from your deck; or Truce: Destroy an enemy, then your opponent draws a Revealed Bronze card.",
             "Flavor": "我们都是他棋盘上的棋子，而这棋局的规则，我们一无所知。"
         },
         "32007": {
@@ -1373,7 +1373,7 @@
         },
         "32009": {
             "Name": "Leo Bonhart",
-            "Info": "Deploy: Reveal one of your units and deal damage equal to its base power to an enemy.",
+            "Info": "Deploy: Reveal one of your units and deal Damage equal to its base power to an enemy.",
             "Flavor": "他就坐在那里，死盯着我，一言不发。他的眼睛，好像……鱼眼，没有眉毛，没有睫毛……活脱脱两颗水球包裹的黑石头。一片死寂中，他就那样凝视着我，这却比被痛打我一顿更让我不寒而栗。"
         },
         "32001": {
@@ -1403,12 +1403,12 @@
         },
         "32014": {
             "Name": "Letho of Gulet",
-            "Info": "Double agent.\nDeploy: Toggle 2 units' Lock on the same row, then drain all their power.",
+            "Info": "Double agent.\nDeploy: Toggle 2 units' Lock on the same row, then Drain all their power.",
             "Flavor": "猎魔人绝不会死在自己的床上。"
         },
         "32015": {
             "Name": "Assassination",
-            "Info": "Deal 9 damage to an enemy.\nRepeat once.",
+            "Info": "Deal 9 Damage to an enemy.\nRepeat once.",
             "Flavor": "“请你出手要多少钱？” “看情况喽。比如说目标是你，大改100奥伦币左右。”"
         },
         "33004": {
@@ -1438,7 +1438,7 @@
         },
         "33008": {
             "Name": "Henry var Attre",
-            "Info": "Deploy: Conceal any number of units.\nIf allies, boost by 2.\nIf enemies, deal 2 damage.",
+            "Info": "Deploy: Conceal any number of units.\nIf allies, boost by 2.\nIf enemies, deal 2 Damage.",
             "Flavor": "我在诺维格瑞驻守了十三年，什么我没见过？残忍、讥嘲、贪欲。可如今发生的事情却让我极度不安"
         },
         "33002": {
@@ -1448,7 +1448,7 @@
         },
         "33009": {
             "Name": "Hefty Helge",
-            "Info": "Deploy: Deal 1 damage to all enemies except those on the opposite row.\nIf this unit was revealed, deal 1 damage to all enemies instead.",
+            "Info": "Deploy: Deal 1 Damage to all enemies except those on the opposite row.\nIf this unit was Revealed, deal 1 Damage to all enemies instead.",
             "Flavor": "并非攻城的最佳选择，却是毁城的行家里手。"
         },
         "33010": {
@@ -1458,12 +1458,12 @@
         },
         "33011": {
             "Name": "Peter Saar Gwynleve",
-            "Info": "Deploy, Choose One: Reset an ally and strengthen it by 3; or reset an enemy and weaken it by 3.",
+            "Info": "Deploy, Choose One: Reset an ally and strengthen it by 3; or Reset an enemy and Weaken it by 3.",
             "Flavor": "这双手不属于什么“阁下”，只属于一介农夫。所以这是农夫与农夫间的对话。"
         },
         "33012": {
             "Name": "Serrit",
-            "Info": "Deploy, Choose One: Deal 7 damage to an enemy or set a revealed opposing unit to 1.",
+            "Info": "Deploy, Choose One: Deal 7 Damage to an enemy or set a Revealed opposing unit to 1.",
             "Flavor": "这是我们必须做的，我并不为此感到羞愧。"
         },
         "33013": {
@@ -1508,12 +1508,12 @@
         },
         "33020": {
             "Name": "Treason",
-            "Info": "Force 2 adjacent enemies to duel each other.",
+            "Info": "Force 2 adjacent enemies to Duel each other.",
             "Flavor": "许多人相信，帝国的实力在于纪律严明的军队与恪尽职守的法师。但事实上，金钱才是尼弗迦德统治世界的关键。"
         },
         "33021": {
             "Name": "Cadaverine",
-            "Info": "Choose One: Deal 3 damage to an enemy and all units that share its categories; or destroy a Bronze or Silver Neutral unit.",
+            "Info": "Choose One: Deal 3 Damage to an enemy and all units that share its categories; or destroy a Bronze or Silver Neutral unit.",
             "Flavor": "我不会拿自己的性命去碰运气。我会拿上一把长剑，厚厚地涂上一层吊死鬼之毒。"
         },
         "33022": {
@@ -1523,7 +1523,7 @@
         },
         "33023": {
             "Name": "Slave Driver",
-            "Info": "Deploy: Set an ally's power to 1 and deal damage to an enemy by the amount of power lost.",
+            "Info": "Deploy: Set an ally's power to 1 and deal Damage to an enemy by the amount of power lost.",
             "Flavor": "奴隶贩子只有一个追求：那就是把他的命令一丝不苟地执行下去。"
         },
         "34004": {
@@ -1578,17 +1578,17 @@
         },
         "34015": {
             "Name": "Deithwen Arbalest",
-            "Info": "Deploy: Deal 4 damage to an enemy. If it is Spying, deal 8 damage instead.",
+            "Info": "Deploy: Deal 4 Damage to an enemy. If it is Spying, deal 8 Damage instead.",
             "Flavor": "我只瞄膝盖，一向如此。"
         },
         "34016": {
             "Name": "Mangonel",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you reveal a card.",
+            "Info": "Deploy: Deal 2 Damage to a random enemy.\nRepeat this ability whenever you Reveal a card.",
             "Flavor": "适用于投掷残骸和干粪。"
         },
         "34017": {
             "Name": "Nauzicaa Sergeant",
-            "Info": "Deploy: Clear Hazards from its row and boost an ally or a revealed unit by 3.",
+            "Info": "Deploy: Clear Hazards from its row and boost an ally or a Revealed unit by 3.",
             "Flavor": "皇帝会教北方人懂点儿规矩的。"
         },
         "34018": {
@@ -1603,12 +1603,12 @@
         },
         "34005": {
             "Name": "Impera Enforcers",
-            "Info": "Deploy: Deal 2 damage to an enemy.\nFor each Spying enemy that appears during your turn, deal 2 damage to an enemy.",
+            "Info": "Deploy: Deal 2 Damage to an enemy.\nFor each Spying enemy that appears during your turn, deal 2 Damage to an enemy.",
             "Flavor": "皇帝最忠诚的贴身护卫，誓死保卫皇帝的安全。"
         },
         "34019": {
             "Name": "Fire Scorpion",
-            "Info": "Deploy: Deal 5 damage to an enemy.\nWhenever you reveal this unit, trigger its ability.",
+            "Info": "Deploy: Deal 5 Damage to an enemy.\nWhenever you Reveal this unit, trigger its ability.",
             "Flavor": "名字与实物可谓风马牛不相及，听上去它好像是某种肥大的红色甲壳生物，但其实是一种由能工巧匠精心设计的大规模杀伤性武器……"
         },
         "34020": {
@@ -1623,22 +1623,22 @@
         },
         "34022": {
             "Name": "Viper Witcher",
-            "Info": "Deploy: Deal 1 damage for each Alchemy card in your starting deck.",
+            "Info": "Deploy: Deal 1 Damage for each Alchemy card in your starting deck.",
             "Flavor": "毒蛇学派将会重生……雷索志在必得。"
         },
         "34023": {
             "Name": "Daerlan Soldier",
-            "Info": "Whenever you reveal this unit, play it on a random row and draw a card.",
+            "Info": "Whenever you Reveal this unit, play it on a random row and draw a card.",
             "Flavor": "我在布莱班特军事学院学到了不少东西，比如洗土豆"
         },
         "34024": {
             "Name": "Alba Pikeman",
-            "Info": "At the beginning of the round, summon one copy from the deck.\n2 armor.",
+            "Info": "At the beginning of the round, Summon one copy from the deck.\n2 Armor.",
             "Flavor": "宣誓效忠吾皇恩希尔·恩瑞斯……不然就受刑吧！"
         },
         "34025": {
             "Name": "Imperial Golem",
-            "Info": "Summon a copy of this unit whenever you reveal a card in your opponent's hand. ",
+            "Info": "Summon a copy of this unit whenever you Reveal a card in your opponent's hand. ",
             "Flavor": "尼弗迦德最强大的法师们终于成功掌握了制造魔像的方法。更棒的是，他们已经“偶尔”能让这些魔像为帝国而战了……"
         },
         "34026": {
@@ -1663,12 +1663,12 @@
         },
         "34001": {
             "Name": "Vicovaro Novice",
-            "Info": "Deploy: Draw the top 2 Bronze Alchemy cards from your Deck.\nPlay 1 and shuffle the other back.",
+            "Info": "Deploy: Draw the top 2 Bronze Alchemy cards from your deck.\nPlay 1 and shuffle the other back.",
             "Flavor": "尼弗迦德的法师们就像手纸。一旦谁被皇帝厌倦，立刻有大把新人迫不及待地赶来补缺。"
         },
         "34029": {
             "Name": "Assassin",
-            "Info": "Spying.\nDeploy: Deal 10 damage to the unit to the left.",
+            "Info": "Spying.\nDeploy: Deal 10 Damage to the unit to the left.",
             "Flavor": "帝国宫廷最受欢迎的职业之一，仅次于抄书吏和轻浮的贵妇。"
         },
         "34030": {
@@ -1678,7 +1678,7 @@
         },
         "34031": {
             "Name": "Venendal Elite",
-            "Info": "Deploy: Switch this unit's power with that of a revealed unit.",
+            "Info": "Deploy: Switch this unit's power with that of a Revealed unit.",
             "Flavor": "艾宾以其顶尖的雇佣兵和轻骑兵闻名天下。"
         },
         "34032": {
@@ -1703,7 +1703,7 @@
         },
         "41001": {
             "Name": "King Radovid V",
-            "Info": "Deploy: Toggle 2 units' Lock statuses.\nIf enemies, deal 5 damage to them.\nCrew.",
+            "Info": "Deploy: Toggle 2 units' Lock statuses.\nIf enemies, deal 5 Damage to them.\nCrew.",
             "Flavor": "身为国王，对待敌人应冷酷无情，对待朋友当慷慨大度。"
         },
         "41002": {
@@ -1738,7 +1738,7 @@
         },
         "42004": {
             "Name": "Vandergrift",
-            "Info": "Deploy: Deal 1 damage to all enemies.\nIf a unit is destroyed, apply Ragh Nar Roog to its row.",
+            "Info": "Deploy: Deal 1 Damage to all enemies.\nIf a unit is destroyed, apply Ragh Nar Roog to its row.",
             "Flavor": "将军本以为洛马克的战争会很快结束，不会有什么损失……结果却陷入了永恒的征战。"
         },
         "42005": {
@@ -1778,12 +1778,12 @@
         },
         "42012": {
             "Name": "Vernon Roche",
-            "Info": "Deploy: Deal 7 damage to an enemy.\nAt the start of the game, add a Blue Stripes Commando to your deck.",
+            "Info": "Deploy: Deal 7 Damage to an enemy.\nAt the start of the game, add a Blue Stripes Commando to your deck.",
             "Flavor": "一位爱国者……也是个令人头疼的家伙。"
         },
         "42013": {
             "Name": "Philippa Eilhart",
-            "Info": "Deploy: Deal 5 damage to an enemy, then deal 4, 3, 2 and 1 damage to random enemies.",
+            "Info": "Deploy: Deal 5 Damage to an enemy, then deal 4, 3, 2 and 1 Damage to random enemies.",
             "Flavor": "王族的权势即将凋零，女术士集会所必将崛起。"
         },
         "43001": {
@@ -1853,7 +1853,7 @@
         },
         "43014": {
             "Name": "Síle de Tansarville",
-            "Info": "Deploy: Play a Bronze or Silver Special card from your hand, then draw a card.",
+            "Info": "Deploy: Play a Bronze or Silver special card from your hand, then draw a card.",
             "Flavor": "女术士集会所缺乏谦逊，对权力的渴望可能会让我们功亏一篑。"
         },
         "43015": {
@@ -1888,7 +1888,7 @@
         },
         "43021": {
             "Name": "Vandergrift's Blade",
-            "Info": "Choose One: Destroy a Bronze or Silver Cursed enemy; or deal 10 damage.\nIf the unit was destroyed, banish it.",
+            "Info": "Choose One: Destroy a Bronze or Silver Cursed enemy; or deal 10 Damage.\nIf the unit was destroyed, Banish it.",
             "Flavor": "在阿德卡莱的一次骑士比武中，赛尔奇克打断了范德格里夫特的长剑。于是，愤怒的范德格里夫特下令铸造一把新的兵刃，还在上面附了强大的符文石。"
         },
         "44001": {
@@ -1898,7 +1898,7 @@
         },
         "44002": {
             "Name": "Ban Ard Tutor",
-            "Info": "Deploy: Swap a card in your hand with a Bronze Special card from your deck.",
+            "Info": "Deploy: Swap a card in your hand with a Bronze special card from your deck.",
             "Flavor": "我一直拿艾瑞图萨学院的女生和班·阿德的愣头小子们作对比。结果总是姑娘们胜出。"
         },
         "44003": {
@@ -1928,7 +1928,7 @@
         },
         "44008": {
             "Name": "Reinforced Trebuchet",
-            "Info": "On turn end, deal 1 damage to a random enemy.",
+            "Info": "On turn end, deal 1 Damage to a random enemy.",
             "Flavor": "感受到了吗？每当这宝贝儿投出巨石，大地都会震颤。"
         },
         "44009": {
@@ -1963,12 +1963,12 @@
         },
         "44015": {
             "Name": "Trebuchet",
-            "Info": "Deploy: Damage 3 adjacent enemies by 1.\nCrewed: Increase the damage dealt by 1.",
+            "Info": "Deploy: Damage 3 adjacent enemies by 1.\nCrewed: Increase the Damage dealt by 1.",
             "Flavor": "城堡可是块硬骨头。快去准备投石机！"
         },
         "44016": {
             "Name": "Aedirnian Mauler",
-            "Info": "Deploy: Deal 4 damage to an enemy.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.",
             "Flavor": "呃，这些家伙真让人头疼。"
         },
         "44017": {
@@ -1978,7 +1978,7 @@
         },
         "44018": {
             "Name": "Battering Ram",
-            "Info": "Deploy: Deal 3 damage.\nIf the unit was destroyed, deal 3 damage to another unit.\nCrewed: Increase initial damage by 1.",
+            "Info": "Deploy: Deal 3 Damage.\nIf the unit was destroyed, deal 3 Damage to another unit.\nCrewed: Increase initial Damage by 1.",
             "Flavor": "不肯开门是吧？那我们就再加把劲敲一敲啰。"
         },
         "44019": {
@@ -2003,17 +2003,17 @@
         },
         "44023": {
             "Name": "Dun Banner Light Cavalry",
-            "Info": "On turn start, if you are losing by more than 25 points, summon this unit to a random row.",
+            "Info": "On turn start, if you are losing by more than 25 points, Summon this unit to a random row.",
             "Flavor": "冷静，所有人保持警惕！这可能是那帮披斗篷戴海狸皮帽的家伙的陷阱……"
         },
         "44024": {
             "Name": "Kaedweni Revenant",
-            "Info": "When you play your next Spell or Item, Spawn a doomed default copy of this unit on its row.\n1 Armor.",
+            "Info": "When you play your next Spell or Item, Spawn a Doomed default copy of this unit on its row.\n1 Armor.",
             "Flavor": "万劫不复的士兵日复一日地过着同一天，就好像奇安凡尼银行的职员一样。"
         },
         "44025": {
             "Name": "Damned Sorceress",
-            "Info": "Deploy: If there is a Cursed unit on this unit's row, deal 7 damage.\nIncrease the damage by 1 for each extra Cursed unit on the same row.",
+            "Info": "Deploy: If there is a Cursed unit on this unit's row, deal 7 Damage.\nIncrease the Damage by 1 for each extra Cursed unit on the same row.",
             "Flavor": "萨宾娜的诅咒谁也不放过，就连其他的女术士也难以幸免。"
         },
         "44026": {
@@ -2023,7 +2023,7 @@
         },
         "44027": {
             "Name": "Blue Stripe Commando",
-            "Info": "Whenever a different Temerian ally with the same power is played, summon a copy of this unit from your deck.",
+            "Info": "Whenever a different Temerian ally with the same power is played, Summon a copy of this unit from your deck.",
             "Flavor": "我愿为泰莫利亚赴汤蹈火，不过大多时候是在排除异己。"
         },
         "44028": {
@@ -2053,12 +2053,12 @@
         },
         "44033": {
             "Name": "Winch",
-            "Info": "Choose One: Resurrect a Bronze Machine and add the doomed category to it; or boost all Machines on your side of the board by 3.",
+            "Info": "Choose One: Resurrect a Bronze Machine and add the Doomed category to it; or boost all Machines on your side of the board by 3.",
             "Flavor": "就是一个绞盘。没什么可大惊小怪的。"
         },
         "44034": {
             "Name": "Bloody Flail",
-            "Info": "Deal 5 damage and Spawn a Specter on a random row.",
+            "Info": "Deal 5 Damage and Spawn a Specter on a random row.",
             "Flavor": "有些武器在整个北方领域都禁止使用。因为它们所造成的伤害超出了人们的想象。"
         },
         "45001": {
@@ -2083,12 +2083,12 @@
         },
         "51002": {
             "Name": "Eithné",
-            "Info": "Deploy: Resurrect a Bronze or Silver Special card.",
+            "Info": "Deploy: Resurrect a Bronze or Silver special card.",
             "Flavor": "树精女王眼似融银，心如冷钢。"
         },
         "51003": {
             "Name": "Filavandrel",
-            "Info": "Deploy: Create a Silver Special card.",
+            "Info": "Deploy: Create a Silver special card.",
             "Flavor": "虽然我们人数不多、四散分离，但我们的内心燃烧得比任何时候都要炽热。"
         },
         "51004": {
@@ -2103,7 +2103,7 @@
         },
         "52002": {
             "Name": "Saesenthessis",
-            "Info": "Deploy: Boost self by 1 for each Dwarf ally on the board and in your hand and deal 1 damage to an enemy for each Elf ally on the board and in your hand.",
+            "Info": "Deploy: Boost self by 1 for each Dwarf ally on the board and in your hand and deal 1 Damage to an enemy for each Elf ally on the board and in your hand.",
             "Flavor": "我继承了父亲的变身能力……好吧，尽管我只有一种变化形态。"
         },
         "52003": {
@@ -2128,7 +2128,7 @@
         },
         "52007": {
             "Name": "Iorveth",
-            "Info": "Deploy: Deal 8 damage to an enemy.\nIf the unit was destroyed, boost all Elves in your hand by 1.",
+            "Info": "Deploy: Deal 8 Damage to an enemy.\nIf the unit was destroyed, boost all Elves in your hand by 1.",
             "Flavor": "国王还是乞丐于我并无差别，人类少一个算一个。"
         },
         "52008": {
@@ -2138,7 +2138,7 @@
         },
         "52009": {
             "Name": "Morenn: Forest Child",
-            "Info": "Ambush: When your opponent plays a Bronze or Silver Special card, flip over and cancel its ability.",
+            "Info": "Ambush: When your opponent plays a Bronze or Silver special card, flip over and cancel its ability.",
             "Flavor": "布洛克莱昂的意义远高于我的生命。她是一位母亲，关怀着自己的孩子们。我至死都要捍卫她。"
         },
         "52010": {
@@ -2153,12 +2153,12 @@
         },
         "52012": {
             "Name": "Iorveth: Meditation",
-            "Info": "Deploy: Force 2 enemies on the same row to duel each other.",
+            "Info": "Deploy: Force 2 enemies on the same row to Duel each other.",
             "Flavor": "即使伊欧菲斯只剩一只眼睛，他内心的洞察力也无人能及。"
         },
         "52013": {
             "Name": "Isengrim: Outlaw",
-            "Info": "Deploy, Choose One: Play a Bronze or Silver Special card from your deck; or Create a Silver Elf.",
+            "Info": "Deploy, Choose One: Play a Bronze or Silver special card from your deck; or Create a Silver Elf.",
             "Flavor": "在我们眼前的便是艾尔斯克德格山道，再往前，就是瑟瑞卡尼亚和哈克兰。这将是一条漫长而危险的道路。要想一同走下去，我们就得摒除彼此的猜忌。"
         },
         "53001": {
@@ -2188,7 +2188,7 @@
         },
         "53006": {
             "Name": "Morenn",
-            "Info": "Ambush: When a unit is played from either hand on your opponent's side, flip over and deal 7 damage to that unit.",
+            "Info": "Ambush: When a unit is played from either hand on your opponent's side, flip over and deal 7 Damage to that unit.",
             "Flavor": "艾思娜女士的女儿继承了她无与伦比的美貌，也同样极端仇视与人类有关的一切。"
         },
         "53007": {
@@ -2203,12 +2203,12 @@
         },
         "53009": {
             "Name": "Aelirenn",
-            "Info": "When 5 Elven allies are on the board, summon this unit.",
+            "Info": "When 5 Elven allies are on the board, Summon this unit.",
             "Flavor": "苟活不如好死。"
         },
         "53010": {
             "Name": "Braenn",
-            "Info": "Deploy: Deal damage equal to this unit's power to an enemy.\nIf a unit was destroyed, boost all your other Dryads and Ambush units in hand, deck, and on board by 1.",
+            "Info": "Deploy: Deal Damage equal to this unit's power to an enemy.\nIf a unit was destroyed, boost all your other Dryads and Ambush units in hand, deck, and on board by 1.",
             "Flavor": "莫娜？不，不。我是布蕾恩。布洛克莱昂的女儿。"
         },
         "53011": {
@@ -2228,7 +2228,7 @@
         },
         "53014": {
             "Name": "Milaen",
-            "Info": "Deploy: Deal 6 damage to the units at the end of a row.",
+            "Info": "Deploy: Deal 6 Damage to the units at the end of a row.",
             "Flavor": "老男爵对待偷猎者向来毫不留情。幸亏麦莉运气够好，老男爵已经死了，他的手下也成了亡命之徒。"
         },
         "53015": {
@@ -2253,12 +2253,12 @@
         },
         "53019": {
             "Name": "Nature's Gift",
-            "Info": "Play a Bronze or Silver Special card from your deck.\nShuffle the others back.",
+            "Info": "Play a Bronze or Silver special card from your deck.\nShuffle the others back.",
             "Flavor": "你们贪得无厌地榨干大地，野蛮强横地攫取它的财富。但在我们这儿，它生机勃勃，春华秋实，慷慨大方。因为它爱我们，正如我们爱它。"
         },
         "53020": {
             "Name": "Pit Trap",
-            "Info": "Apply a Hazard to an enemy row that deals 3 damage to units on contact.",
+            "Info": "Apply a Hazard to an enemy row that deals 3 Damage to units on contact.",
             "Flavor": "简单、廉价，又十分好用。难怪它是松鼠党最喜欢用的一种陷阱。"
         },
         "53021": {
@@ -2303,12 +2303,12 @@
         },
         "54008": {
             "Name": "Dol Blathanna Archer",
-            "Info": "Deploy: Deal 3 damage, then deal 1 damage.",
+            "Info": "Deploy: Deal 3 Damage, then deal 1 Damage.",
             "Flavor": "再走一步试试，人类。你眉宇间插根箭肯定好看得多。"
         },
         "54009": {
             "Name": "Dol Blathanna Bowman",
-            "Info": "Deploy: Deal 2 damage to an enemy.\nWhenever an enemy moves, deal 2 damage to it.\nWhenever this unit moves, deal 2 damage to a random enemy.",
+            "Info": "Deploy: Deal 2 Damage to an enemy.\nWhenever an enemy moves, deal 2 Damage to it.\nWhenever this unit moves, deal 2 Damage to a random enemy.",
             "Flavor": "也许你能躲过他们，但要被发现了，就别浪费时间逃跑了。"
         },
         "54010": {
@@ -2323,7 +2323,7 @@
         },
         "54012": {
             "Name": "Mahakam Marauder",
-            "Info": "Whenever this unit is boosted, damaged, strengthened or weakened, boost it by 2.",
+            "Info": "Whenever this unit is boosted, Damaged, strengthened or Weakened, boost it by 2.",
             "Flavor": "在玛哈坎崎岖的悬崖峭壁上狩猎可不是件简单事……但矮人们也从不轻易向危险低头。"
         },
         "54013": {
@@ -2338,7 +2338,7 @@
         },
         "54015": {
             "Name": "Dwarven Skirmisher",
-            "Info": "Deploy: Deal 3 damage to an enemy.\nIf the unit was not destroyed, boost self by 3.",
+            "Info": "Deploy: Deal 3 Damage to an enemy.\nIf the unit was not destroyed, boost self by 3.",
             "Flavor": "我跟十字镐打了一辈子交道，动动斧头算什么问题？"
         },
         "54016": {
@@ -2348,17 +2348,17 @@
         },
         "54017": {
             "Name": "Half-Elf Hunter",
-            "Info": "Deploy: Spawn a doomed default copy of this unit.",
+            "Info": "Deploy: Spawn a Doomed default copy of this unit.",
             "Flavor": "被人类痛恨，被精灵唾骂，而且学校操场上谁都不肯带他们玩。难怪半精灵一肚子委屈。"
         },
         "54018": {
             "Name": "Hawker Healer",
-            "Info": "Deploy: Boost 2 allies by 3, then heal them.",
+            "Info": "Deploy: Boost 2 allies by 3, then Heal them.",
             "Flavor": "帮你包扎，没问题——只要你有钱。"
         },
         "54019": {
             "Name": "Pyrotechnician",
-            "Info": "Deploy: Deal 3 damage to a random enemy on each row.",
+            "Info": "Deploy: Deal 3 Damage to a random enemy on each row.",
             "Flavor": "在玛哈坎，这份行当的风险非同一般，因此回报也异常优厚。其中最负盛名的行业翘楚，当数那位名叫麦柯尔·贝的矮人。"
         },
         "54020": {
@@ -2368,7 +2368,7 @@
         },
         "54021": {
             "Name": "Elven Swordmaster",
-            "Info": "Deploy: Deal damage equal to this unit's power.",
+            "Info": "Deploy: Deal Damage equal to this unit's power.",
             "Flavor": "战斗如同舞蹈，千万不能让你的对手领舞。"
         },
         "54022": {
@@ -2378,7 +2378,7 @@
         },
         "54023": {
             "Name": "Panther",
-            "Info": "Deploy: Deal 7 damage to an enemy on a row with less than 4 units.",
+            "Info": "Deploy: Deal 7 Damage to an enemy on a row with less than 4 units.",
             "Flavor": "曾经有位牛堡学者在观察一只黑豹后，宣称它不过是颜色不同的花豹而已。黑豹貌似对这一说法毫不关心。他还没等学者完成研究，就把他狼吞虎咽地吃下了肚。"
         },
         "54024": {
@@ -2398,12 +2398,12 @@
         },
         "54027": {
             "Name": "Dol Blathanna Sentry",
-            "Info": "If in hand, deck or on board, boost self by 1 whenever you play a Special card.",
+            "Info": "If in hand, deck or on board, boost self by 1 whenever you play a special card.",
             "Flavor": "只要我们一息尚存，就绝不容许人类践踏多尔·布雷坦纳的绿荫。"
         },
         "54028": {
             "Name": "Sage",
-            "Info": "Deploy: Resurrect a Bronze Alchemy or Spell card, then banish it.",
+            "Info": "Deploy: Resurrect a Bronze Alchemy or Spell card, then Banish it.",
             "Flavor": "亲爱的，知识，乃是一种特权。而特权，只能被实力相当的人所分享。"
         },
         "54029": {
@@ -2413,17 +2413,17 @@
         },
         "54030": {
             "Name": "Elven Mercenary",
-            "Info": "Deploy: Look at 2 random Bronze Special cards from your deck, then play 1.",
+            "Info": "Deploy: Look at 2 random Bronze special cards from your deck, then play 1.",
             "Flavor": "我瞧不起松鼠党，但不讨厌他们的钱。"
         },
         "54031": {
             "Name": "Elven Blade",
-            "Info": "Deal 10 damage to a non-Elf unit.",
+            "Info": "Deal 10 Damage to a non-Elf unit.",
             "Flavor": "精灵的利剑轻盈，却能造成重伤。"
         },
         "54032": {
             "Name": "Crushing Trap",
-            "Info": "Deal 6 damage to the units at the end of an enemy row.",
+            "Info": "Deal 6 Damage to the units at the end of an enemy row.",
             "Flavor": "要是被它击倒，你就别想在爬起来了。"
         },
         "55001": {
@@ -2433,7 +2433,7 @@
         },
         "62001": {
             "Name": "Olaf",
-            "Info": "Deploy: Deal 10 damage to self.\nReduce the damage inflicted by 2 for each Beast you played this match.",
+            "Info": "Deploy: Deal 10 Damage to self.\nReduce the Damage inflicted by 2 for each Beast you played this match.",
             "Flavor": "备受敬仰的小史凯利格岛竞技场十冠王。"
         },
         "62002": {
@@ -2443,7 +2443,7 @@
         },
         "62003": {
             "Name": "Vabjorn",
-            "Info": "Deploy: Deal 2 damage.\nIf the unit was already damaged, destroy it instead.",
+            "Info": "Deploy: Deal 2 Damage.\nIf the unit was already Damaged, destroy it instead.",
             "Flavor": "为了斯瓦勃洛！"
         },
         "62004": {
@@ -2453,7 +2453,7 @@
         },
         "62005": {
             "Name": "Wild Boar of the Sea",
-            "Info": "On turn end, strengthen the unit to the left by 1, then deal 1 damage to the unit to the right.\n5 Armor.",
+            "Info": "On turn end, strengthen the unit to the left by 1, then deal 1 Damage to the unit to the right.\n5 Armor.",
             "Flavor": "只消对尼弗迦德人提起这个名字，他们就会吓得尿裤子……"
         },
         "62006": {
@@ -2463,22 +2463,22 @@
         },
         "62007": {
             "Name": "Cerys an Craite",
-            "Info": "When 4 units are resurrected while this unit is in the graveyard, resurrect it and strenghten it by 1.",
+            "Info": "When 4 units are resurrected while this unit is in the graveyard, resurrect it and Strenghten it by 1.",
             "Flavor": "大家叫我小雀鹰，知道为什么吗？因为我专治你这种鼠辈。"
         },
         "62008": {
             "Name": "Madman Lugos",
-            "Info": "Deploy: Discard a Bronze unit from your deck and damage a unit by the Discarded unit's base power.",
+            "Info": "Deploy: Discard a Bronze unit from your deck and Damage a unit by the Discarded unit's base power.",
             "Flavor": "哇哇哇哇哇哇啊！！！！"
         },
         "62009": {
             "Name": "Ulfhedinn",
-            "Info": "Deploy: Deal 1 damage to all enemies.\nIf the enemies were damaged, deal 2 damage instead.",
+            "Info": "Deploy: Deal 1 Damage to all enemies.\nIf the enemies were Damaged, deal 2 Damage instead.",
             "Flavor": "狼人？哦，不，不……比那要糟糕得多。"
         },
         "62010": {
             "Name": "Cerys: Fearless",
-            "Info": "Resurrect the next unit you discard.",
+            "Info": "Resurrect the next unit you Discard.",
             "Flavor": "我必须要团结各大家族。我希望能够避免开战。但假如尼弗迦德执意来犯，那我们就一定要同仇敌忾。"
         },
         "62011": {
@@ -2498,17 +2498,17 @@
         },
         "63001": {
             "Name": "Jutta an Dimun",
-            "Info": "Deploy: Deal 1 damage to self.",
+            "Info": "Deploy: Deal 1 Damage to self.",
             "Flavor": "有人称她“铁娘子”。"
         },
         "63002": {
             "Name": "Udalryk",
-            "Info": "Spying. Single-Use.\nDeploy: Look at 2 cards from your deck.\nDraw one and discard the other.",
+            "Info": "Spying. Single-Use.\nDeploy: Look at 2 cards from your deck.\nDraw one and Discard the other.",
             "Flavor": "诸神已经发话，必须献上祭品。"
         },
         "63003": {
             "Name": "Djenge Frett",
-            "Info": "Deploy: Deal 1 damage to 2 allies and strengthen self by 2 for each.",
+            "Info": "Deploy: Deal 1 Damage to 2 allies and strengthen self by 2 for each.",
             "Flavor": "如果通缉令上写着“无论死活”，绝大多数赏金猎人会直接快刀斩乱麻。但我不会。如果被我抓到，我会把人吊起来挠痒，让他笑到岔气。"
         },
         "63004": {
@@ -2518,12 +2518,12 @@
         },
         "63005": {
             "Name": "Morkvarg",
-            "Info": "Whenever this unit enter the graveyard, resurrect it and weaken it by half.",
+            "Info": "Whenever this unit enter the graveyard, resurrect it and Weaken it by half.",
             "Flavor": "史凯利格有史以来最大的恶人。"
         },
         "63006": {
             "Name": "Svanrige Tuirseach",
-            "Info": "Deploy: Draw a card, then discard a card.",
+            "Info": "Deploy: Draw a card, then Discard a card.",
             "Flavor": "皇帝最开始也认为自己登上皇位是出于偶然。"
         },
         "63007": {
@@ -2548,7 +2548,7 @@
         },
         "63011": {
             "Name": "Holger Blackhand",
-            "Info": "Deploy: Deal 7 damage.\nIf the unit was destroyed, strengthen the Highest unit in your graveyard by 3.",
+            "Info": "Deploy: Deal 7 Damage.\nIf the unit was destroyed, strengthen the Highest unit in your graveyard by 3.",
             "Flavor": "敬尼弗迦德皇帝，祝他不得善终！"
         },
         "63012": {
@@ -2558,12 +2558,12 @@
         },
         "63013": {
             "Name": "Yoana",
-            "Info": "Deploy: Heal an ally, then boost it by the amount healed.",
+            "Info": "Deploy: Heal an ally, then boost it by the amount Healed.",
             "Flavor": "没人会把我当成一名老练的盔甲师傅。只是一个人类，而且还是个女人。可是矮人铁匠就不同了……"
         },
         "63014": {
             "Name": "Derran",
-            "Info": "Whenever an enemy is damaged, boost this unit by 1.",
+            "Info": "Whenever an enemy is Damaged, boost this unit by 1.",
             "Flavor": "能引发这样的疯狂，相比是极其可怖的……"
         },
         "63015": {
@@ -2588,7 +2588,7 @@
         },
         "63019": {
             "Name": "Restore",
-            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the doomed category to it, and set its base power to 8.\nThen play a card.",
+            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base power to 8.\nThen play a card.",
             "Flavor": "那些该死的女术士又抢咱们的风头！只要几个年轻姑娘挥挥手就能解决的话，谁还选择这么费时费力的办法？"
         },
         "63020": {
@@ -2598,7 +2598,7 @@
         },
         "64001": {
             "Name": "An Craite Warrior",
-            "Info": "Deploy: Deal 1 damage to self.",
+            "Info": "Deploy: Deal 1 Damage to self.",
             "Flavor": "我们的吟游诗人会世代传颂我的功绩，而你死了就会被世人遗忘！"
         },
         "64002": {
@@ -2618,7 +2618,7 @@
         },
         "64005": {
             "Name": "Berserker Marauder",
-            "Info": "Deploy: Boost self by 1 for each damaged or Cursed ally.",
+            "Info": "Deploy: Boost self by 1 for each Damaged or Cursed ally.",
             "Flavor": "把汤乖乖喝完，不然狂战士就会过来，把你给掳走。"
         },
         "64006": {
@@ -2633,17 +2633,17 @@
         },
         "64008": {
             "Name": "Savage Bear",
-            "Info": "Whenever a unit is played from either hand on your opponent's side, deal 1 damage to it.",
+            "Info": "Whenever a unit is played from either hand on your opponent's side, deal 1 Damage to it.",
             "Flavor": "“驯服”？哈，小子，史凯利格人也许能训练它们，但那跟驯服完全不同……"
         },
         "64009": {
             "Name": "An Craite Greatsword",
-            "Info": "Every 2 turns, on turn start, if damaged, heal self and strengthen by 2.",
+            "Info": "Every 2 turns, on turn start, if Damaged, Heal self and strengthen by 2.",
             "Flavor": "啊哈哈，你真让我笑掉大牙，北方佬！怎么？我手上这把大家伙，你都不一定拿得动，还想用它对付我？"
         },
         "64010": {
             "Name": "Tuirseach Archer",
-            "Info": "Deploy: Deal 1 damage to 3 units.",
+            "Info": "Deploy: Deal 1 Damage to 3 units.",
             "Flavor": "你能射中两百步外的移动靶吗？我能，而且是在暴风雨中。"
         },
         "64011": {
@@ -2658,12 +2658,12 @@
         },
         "64013": {
             "Name": "Svalblod Ravager",
-            "Info": "Whenever this unit is damaged or weakened, transform into a Raging Bear.",
+            "Info": "Whenever this unit is Damaged or Weakened, transform into a Raging Bear.",
             "Flavor": "在诗人的歌谣里，鏖战中变身的狂战士跟野熊没两样。"
         },
         "64014": {
             "Name": "An Craite Whaler",
-            "Info": "Deploy: Move an enemy to the opposite row, then deal damage equal to the number of units on that row.",
+            "Info": "Deploy: Move an enemy to the opposite row, then deal Damage equal to the number of units on that row.",
             "Flavor": "无论是海上还是港口，他们盯上的目标永远是最漂亮的那个。"
         },
         "64015": {
@@ -2678,32 +2678,32 @@
         },
         "64017": {
             "Name": "Dimun Light Longship",
-            "Info": "On turn end, deal 1 damage to the unit to the right, then boost self by 2.",
+            "Info": "On turn end, deal 1 Damage to the unit to the right, then boost self by 2.",
             "Flavor": "你以为能在史凯利格海域逃出他们的手掌心？自求多福吧。"
         },
         "64018": {
             "Name": "An Craite Longship",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you discard a card.",
+            "Info": "Deploy: Deal 2 Damage to a random enemy.\nRepeat this ability whenever you Discard a card.",
             "Flavor": "据说只要有长船出海劫掠，汉姆多尔就会心潮澎湃。"
         },
         "64019": {
             "Name": "Dimun Warship",
-            "Info": "Deploy: Deal 1 damage to the same unit 4 times.",
+            "Info": "Deploy: Deal 1 Damage to the same unit 4 times.",
             "Flavor": "迪门家族的战船轻盈迅捷，最适合追逐缓慢笨重的商船。"
         },
         "64020": {
             "Name": "An Craite Marauder",
-            "Info": "Deploy: Deal 4 damage.\nIf resurrected, deal 6 damage instead.",
+            "Info": "Deploy: Deal 4 Damage.\nIf resurrected, deal 6 Damage instead.",
             "Flavor": "你疯了不成？你想去史凯利格？哪些野蛮人会让你吃大苦头的！"
         },
         "64021": {
             "Name": "Tuirseach Hunter",
-            "Info": "Deploy: Deal 5 damage.",
+            "Info": "Deploy: Deal 5 Damage.",
             "Flavor": "别怀疑我们的狩猎本领，只恨史派克鲁格的猎物太少……"
         },
         "64022": {
             "Name": "Tuirseach Axeman",
-            "Info": "Whenever an enemy on the opposite row is damaged, boost self by 1.\n2 Armor.",
+            "Info": "Whenever an enemy on the opposite row is Damaged, boost self by 1.\n2 Armor.",
             "Flavor": "小姑娘才用剑，弄把斧头吧。"
         },
         "64023": {
@@ -2713,7 +2713,7 @@
         },
         "64024": {
             "Name": "An Craite Raider",
-            "Info": "Whenever you discard this unit, resurrect it.",
+            "Info": "Whenever you Discard this unit, resurrect it.",
             "Flavor": "我们可是奎特家族！別人用金子购买，我们拿血汗交换。"
         },
         "64025": {
@@ -2723,7 +2723,7 @@
         },
         "64026": {
             "Name": "Drummond Shieldmaid",
-            "Info": "Deploy: Deal 2 damage to an enemy unit. If the target was already injured, play one copy from the deck.",
+            "Info": "Deploy: Deal 2 Damage to an enemy unit. If the target was already injured, play one copy from the deck.",
             "Flavor": "我们的敌人会像打上嶙峋海岸的波浪一样，倒在我们的盾前。"
         },
         "64027": {
@@ -2738,7 +2738,7 @@
         },
         "64029": {
             "Name": "Heymaey Spearmaiden",
-            "Info": "Deploy: Deal 1 damage to a Machine or Soldier ally, then play a copy of it from your deck.",
+            "Info": "Deploy: Deal 1 Damage to a Machine or Soldier ally, then play a copy of it from your deck.",
             "Flavor": "“史凯利格的女人生性狂野，难以捉摸。所有的部队都要把她们视为严重的威胁，绝不能低估她们的实力。”—将军对帝国舰队入侵部队下的指令"
         },
         "64030": {
@@ -2763,7 +2763,7 @@
         },
         "64034": {
             "Name": "Bone Talisman",
-            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or heal an ally and strengthen it by 3.",
+            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or Heal an ally and strengthen it by 3.",
             "Flavor": "有时最普通不过的物件却拥有最为强大的威力。"
         },
         "65001": {
@@ -2783,7 +2783,7 @@
         },
         "65004": {
             "Name": "Spectral Whale",
-            "Info": "Spying.\nOn turn end, move to a random row and deal 1 damage to all units on it.",
+            "Info": "Spying.\nOn turn end, move to a random row and deal 1 Damage to all units on it.",
             "Flavor": "“呃，座头鲸应该没那么大。那是头长须鲸。”“嘴那么短的长须鲸？你被药草冲昏了头吗！”"
         },
         "65005": {
@@ -2803,7 +2803,7 @@
         },
         "61001": {
             "Name": "Harald the Cripple",
-            "Info": "Deploy: Split 10 damage randomly between enemies on the opposite row.",
+            "Info": "Deploy: Split 10 Damage randomly between enemies on the opposite row.",
             "Flavor": "没人知道他的绰号从何而来，更没人敢问。"
         },
         "61002": {
@@ -2823,27 +2823,27 @@
         },
         "70001": {
             "Name": "Quen",
-            "Info": "Choose a Bronze or Silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any damage once.",
+            "Info": "Choose a Bronze or Silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any Damage once.",
             "Flavor": ""
         },
         "70002": {
             "Name": "Detlaff: Higher Vampire",
-            "Info": "Deploy, Choose one: Play a Bronze unit from your deck with power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or consume a bronze unit from your deck with more power than this unit and gain its power.",
+            "Info": "Deploy, Choose One: Play a Bronze unit from your deck with power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or Consume a bronze unit from your deck with more power than this unit and gain its power.",
             "Flavor": ""
         },
         "70003": {
             "Name": "Hammond",
-            "Info": "Deploy, Choose one: Spawn a Skellige Bronze Machine; or boost all friendly Machines on the board by 2.\nUnits in this row are immune to damage from Hazards.",
+            "Info": "Deploy, Choose One: Spawn a Skellige Bronze Machine; or boost all friendly Machines on the board by 2.\nUnits in this row are Immune to Damage from Hazards.",
             "Flavor": ""
         },
         "70004": {
             "Name": "Glynnis Aep Loernach",
-            "Info": "On turn end, if at the top or bottom of the deck, summon it to a random row.",
+            "Info": "On turn end, if at the top or bottom of the deck, Summon it to a random row.",
             "Flavor": ""
         },
         "70005": {
             "Name": "Vysogota Of Corvo",
-            "Info": "On round start, boost a unit to the left by 3, then damage self by 1 and move to the row with the least amount of units.\nDeathwish: Boost the Lowest ally by 6.",
+            "Info": "On round start, boost a unit to the left by 3, then Damage self by 1 and move to the row with the least amount of units.\nDeathwish: Boost the Lowest ally by 6.",
             "Flavor": ""
         },
         "70006": {
@@ -2853,17 +2853,17 @@
         },
         "70007": {
             "Name": "Prophet Lebioda",
-            "Info": "When banished, boost all allies by 1.",
+            "Info": "When Banished, boost all allies by 1.",
             "Flavor": ""
         },
         "70008": {
             "Name": "Vivienne: Oriole",
-            "Info": "On turn end, if your total power exceeds the opponent's power by 25 points or more, return to your hand.",
+            "Info": "On turn end, if your total power exceeds the opponent's power by 25 or more, return to your hand.",
             "Flavor": ""
         },
         "70009": {
             "Name": "Fleder",
-            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy unit becomes damaged, boost self by 1.",
+            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy unit becomes Damaged, boost self by 1.",
             "Flavor": ""
         },
         "70010": {
@@ -2883,22 +2883,22 @@
         },
         "70013": {
             "Name": "Corrupted Flaminca",
-            "Info": "Deploy: Discard a Torrential Rain from your deck, then spawn Torrential Rain on this unit's row and on the opposing row.",
+            "Info": "Deploy: Discard a Torrential Rain from your deck, then Spawn Torrential Rain on this unit's row and on the opposing row.",
             "Flavor": ""
         },
         "70014": {
             "Name": "The Goddess of Justice",
-            "Info": "Bid for the Red Coin. Choose how many points you are willing to give up to start the game second. At the end of the first round, this card is summoned to Blue Coin player's board from the graveyard.",
+            "Info": "Bid for the Red Coin. Choose how many points you are willing to give up to start the game second. At the end of the first round, this card is Summoned to Blue Coin player's board from the graveyard.",
             "Flavor": ""
         },
         "70015": {
             "Name": "Brokilon Sentinel",
-            "Info": "On round end, if the opponent has exactly 4 units in the opposing row, deal 1 damage to all enemy units in that row.",
+            "Info": "On round end, if the opponent has exactly 4 units in the opposing row, deal 1 Damage to all enemy units in that row.",
             "Flavor": ""
         },
         "70016": {
             "Name": "Sukrus",
-            "Info": "Deploy: Choose 1 Bronze card in your hand and discard all cards with the same name from the deck.",
+            "Info": "Deploy: Choose 1 Bronze card in your hand and Discard all cards with the same name from the deck.",
             "Flavor": ""
         },
         "70017": {
@@ -2923,7 +2923,7 @@
         },
         "70022": {
             "Name": "Kikimore Worker",
-            "Info": "Deploy: Choose an Insectoid ally, then boost all the cards with the same name on your side of the board, hand and deck by 2 points.",
+            "Info": "Deploy: Choose an Insectoid ally, then boost all the cards with the same name on your side of the board, hand and deck by 2.",
             "Flavor": ""
         },
         "70023": {
@@ -2933,7 +2933,7 @@
         },
         "70024": {
             "Name": "Cursed Immortals",
-            "Info": "When an adjacent Cursed unit is destroyed, spawn a Specter on this row.",
+            "Info": "When an adjacent Cursed unit is destroyed, Spawn a Specter on this row.",
             "Flavor": ""
         },
         "70025": {
@@ -2943,7 +2943,7 @@
         },
         "70026": {
             "Name": "Ivo of Belhaven",
-            "Info": "On round start, if you have more points than the opponent, strengthen self by 2 points.\nDeathwish: Move a random Bronze or Silver Witcher in your deck to the top of your deck.",
+            "Info": "On round start, if you have more points than the opponent, strengthen self by 2.\nDeathwish: Move a random Bronze or Silver Witcher in your deck to the top of your deck.",
             "Flavor": ""
         },
         "70027": {
@@ -2953,12 +2953,12 @@
         },
         "70032": {
             "Name": "Gascon",
-            "Info": "Deploy: Move all units to a random other row and damage self by 2 for each unit moved.\nWhen in your hand or deck, boost self by 1 whenever a unit moves during your turn.",
+            "Info": "Deploy: Move all units to a random other row and Damage self by 2 for each unit moved.\nWhen in your hand or deck, boost self by 1 whenever a unit moves during your turn.",
             "Flavor": "“Th' Strays of Spalla – 'tis you who lead them? 'Tis you they call the Duke of Dogs?”"
         },
         "70033": {
             "Name": "War Elephant",
-            "Info": "Deploy: Destroy the Armor of all units on a row on your side of the board, then damage a unit by the amount destroyed.",
+            "Info": "Deploy: Destroy the Armor of all units on a row on your side of the board, then Damage a unit by the amount destroyed.",
             "Flavor": ""
         },
         "70038": {
@@ -2968,12 +2968,12 @@
         },
         "70039": {
             "Name": "Dire Wolf Claws",
-            "Info": "Deal 4 damage to a random enemy.\nWhen discarded, trigger its ability and add 2 copies of Dire Wolf Warrior in your deck.",
+            "Info": "Deal 4 Damage to a random enemy.\nWhen Discarded, trigger its ability and add 2 copies of Dire Wolf Warrior in your deck.",
             "Flavor": ""
         },
         "70040": {
             "Name": "Dire Wolf Warrior",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nWhen discarded, trigger its ability and add a copy of this card to the bottom of your deck.",
+            "Info": "Deploy: Deal 2 Damage to a random enemy.\nWhen Discarded, trigger its ability and add a copy of this card to the bottom of your deck.",
             "Flavor": ""
         },
         "70041": {
@@ -2988,7 +2988,7 @@
         },
         "70043": {
             "Name": "Vernossiel's Commando",
-            "Info": "After you Swap this unit twice, summon it to a random row.",
+            "Info": "After you Swap this unit twice, Summon it to a random row.",
             "Flavor": ""
         },
         "70044": {
@@ -3003,7 +3003,7 @@
         },
         "70046": {
             "Name": "Svalblod Fanatic",
-            "Info": "On round end, deal 3 damage to the Lowest enemy, then deal 3 damage to self.",
+            "Info": "On round end, deal 3 Damage to the Lowest enemy, then deal 3 Damage to self.",
             "Flavor": ""
         },
         "70050": {
@@ -3013,7 +3013,7 @@
         },
         "70054": {
             "Name": "Feign Death",
-            "Info": "Resurrect 2 Bronze units with power higher than 5, then deal 4 damage to each of them.",
+            "Info": "Resurrect 2 Bronze units with power higher than 5, then deal 4 Damage to each of them.",
             "Flavor": ""
         },
         "70058": {
@@ -3028,12 +3028,12 @@
         },
         "70062": {
             "Name": "Living Armor",
-            "Info": "Units in the same row as this unit take at most 5 damage at once.",
+            "Info": "Units in the same row as this unit take at most 5 Damage at once.",
             "Flavor": "价钱是贵了点。但是你把节省下来的吃住都算进去，不出一百年就能回本！"
         },
         "70070": {
             "Name": "Highwaymen",
-            "Info": "Single-use.\nIf there are only Bronze cards in your starting deck, spawn a Strays of Spalla, then add two copy of Strays of Spalla to your deck.",
+            "Info": "Single-use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two copy of Strays of Spalla to your deck.",
             "Flavor": "“商人？抹了。马匹？卖了。”"
         },
         "70071": {
@@ -3043,27 +3043,27 @@
         },
         "70072": {
             "Name": "Radeyah",
-            "Info": "Deploy: Deal damage equal to the number of neutral cards in your hand.",
+            "Info": "Deploy: Deal Damage equal to the number of neutral cards in your hand.",
             "Flavor": "“迷人的微笑背后可以潜藏许多秘密……”"
         },
         "70076": {
             "Name": "Congregation Cleric",
-            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base strenght to 2. Whenever any Bronze unit is locked during your turn, generate a copy of it with 2 base strength in the same row as this unit.",
+            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base Strenght to 2. Whenever any Bronze unit is locked during your turn, generate a copy of it with 2 base strength in the same row as this unit.",
             "Flavor": "“靠近点，羔羊，再近点。愿永恒之火温暖你的灵魂！”"
         },
         "70077": {
             "Name": "Firesworn Zealot",
-            "Info": "Every 4 turns, at the end of the turn, deal 2 damage to 4 random enemies. Reduce the countdown by 1 for each locked unit on the board when played.",
+            "Info": "Every 4 turns, at the end of the turn, deal 2 Damage to 4 random enemies. Reduce the countdown by 1 for each locked unit on the board when played.",
             "Flavor": "“我的信仰无人能敌，亦如我的怒火！”"
         },
         "70078": {
             "Name": "Damnation",
-            "Info": "Summon the two Highest Bronze units from the deck to the same row, then change their lock status.",
+            "Info": "Summon the two Highest Bronze units from the deck to the same row, then change their Lock status.",
             "Flavor": "“呛死我了！就不能去别的地方烧吗？”"
         },
         "70091": {
             "Name": "Magic Lamp",
-            "Info": "At the start of the game, add 3 copies of The Last Wish to your deck, then discard self.",
+            "Info": "At the start of the game, add 3 copies of The Last Wish to your deck, then Discard self.",
             "Flavor": "破译梦境中的过去和未来是非常困难的，即使对大师也是如此。"
         },
         "70102": {
@@ -3073,7 +3073,7 @@
         },
         "70103": {
             "Name": "Artorius Vigo",
-            "Info": "Deploy: Discard a card, then add a Bronze unit from your starting deck to your hand and reveal it.",
+            "Info": "Deploy: Discard a card, then add a Bronze unit from your starting deck to your hand and Reveal it.",
             "Flavor": "“据说他创造出的幻象栩栩如生，连他自己都开始信了……”"
         },
         "70104": {
@@ -3113,7 +3113,7 @@
         },
         "130220": {
             "Name": "Prize-Winning Cow: Promoted",
-            "Info": "Deathwish: Spawn a Chort，and then deal 2 damage to all emenies on the same row",
+            "Info": "Deathwish: Spawn a Chort，and then deal 2 Damage to all emenies on the same row",
             "Flavor": "哞～～～"
         },
         "130200": {
@@ -3133,7 +3133,7 @@
         },
         "130010": {
             "Name": "Roach: Promoted",
-            "Info": "Whenever you play a Gold unit from your hand, summon this unit.\nIf it is in your hand, summon it and draw one card.\nIf it is in your graveyard, return to your deck.",
+            "Info": "Whenever you play a Gold unit from your hand, Summon this unit.\nIf it is in your hand, Summon it and draw one card.\nIf it is in your graveyard, return to your deck.",
             "Flavor": "杰洛特，我们得来场人马间的对话。恕我直言，你的骑术……真的有待提高，伙计。"
         },
         "130150": {
@@ -3168,7 +3168,7 @@
         },
         "130110": {
             "Name": "Carlo Varese",
-            "Info": "Deal 9 damage.\nDeal overflowed damge to adjacent cards.",
+            "Info": "Deal 9 Damage.\nDeal overflowed damge to adjacent cards.",
             "Flavor": "每个想要在诺维格瑞做生意的都很清楚——要么同意卡罗的条件，要么就夹着尾巴滚出去。"
         },
         "130090": {
@@ -3178,7 +3178,7 @@
         },
         "130100": {
             "Name": "Ocvist: Promoted",
-            "Info": "Single-Use.\nAfter 3 turns, deal 1 damage to all enemies, then on round start, return to your hand.",
+            "Info": "Single-Use.\nAfter 3 turns, deal 1 Damage to all enemies, then on round start, return to your hand.",
             "Flavor": "他是石英山之主，毁灭者，图拉真的屠夫。但在闲暇时间里，他喜欢远足和烛光晚餐。"
         },
         "130120": {
@@ -3188,7 +3188,7 @@
         },
         "130080": {
             "Name": "Johnny: Promoted",
-            "Info": "Deploy: Discard a card, then create a copy of a card of the same color from your opponent's starting deck in your hand.",
+            "Info": "Deploy: Discard a card, then Create a copy of a card of the same color from your opponent's starting deck in your hand.",
             "Flavor": "要是再也没办法亲口说出“狮子头上长虱子”，生活就真的太无趣啦。"
         },
         "130050": {
@@ -3218,17 +3218,17 @@
         },
         "640080": {
             "Name": "Savage Bear: Promoted",
-            "Info": "Whenever a unit appears on your opponent's side, deal 1 damage to it.",
+            "Info": "Whenever a unit appears on your opponent's side, deal 1 Damage to it.",
             "Flavor": "“驯服”？哈，小子，史凯利格人也许能训练它们，但那跟驯服完全不同……"
         },
         "240140": {
             "Name": "Drowner: Promoted",
-            "Info": "Deploy: Move 2 enemies to the opposite row and deal 2 damage to it.\nIf that row is under a Hazard, deal 4 damage instead.",
+            "Info": "Deploy: Move 2 enemies to the opposite row and deal 2 Damage to it.\nIf that row is under a Hazard, deal 4 Damage instead.",
             "Flavor": "尽管猎魔人想多赚些金币，但杀水鬼这活儿只值一枚银币，或者三个铜板——不能再多了。"
         },
         "240230": {
             "Name": "Wyvern: Promoted",
-            "Info": "Deal 7 damage.",
+            "Info": "Deal 7 Damage.",
             "Flavor": "想象一下在最可怕的噩梦中出现的长翅膀的蛇——翼手龙比这更可怕。"
         },
         "240250": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -2873,7 +2873,7 @@
         },
         "70011": {
             "Name": "Lady Of The Lake: Advent",
-            "Info": "Spawn \"Lady Of The Lake\". (Deploy: Weaken self by the value equal to twice the number of the remaining cards in your hand and deck)",
+            "Info": "Spawn Lady Of The Lake. (Deploy: Weaken self by the value equal to twice the number of the remaining cards in your hand and deck)",
             "Flavor": ""
         },
         "70012": {
@@ -2883,7 +2883,7 @@
         },
         "70013": {
             "Name": "Corrupted Flaminca",
-            "Info": "Deploy: Discard a \"Torrential Rain\" from your deck, then spawn \"Torrential Rain\" on this unit's row and on the opposing row.",
+            "Info": "Deploy: Discard a Torrential Rain from your deck, then spawn Torrential Rain on this unit's row and on the opposing row.",
             "Flavor": ""
         },
         "70014": {
@@ -2898,47 +2898,47 @@
         },
         "70016": {
             "Name": "Sukrus",
-            "Info": "Deploy: Choose 1 bronze card in the hand and discard all cards with the same name from the deck.",
+            "Info": "Deploy: Choose 1 Bronze card in your hand and discard all cards with the same name from the deck.",
             "Flavor": ""
         },
         "70017": {
             "Name": "Cintrian Field Medic",
-            "Info": "Deploy: Shuffle a non-identical friendly bronze unit back to the deck, and then play a random bronze unit card from the deck.",
+            "Info": "Deploy: Shuffle a non-identical friendly Bronze unit back to the deck, and then play a random Bronze unit from the deck.",
             "Flavor": ""
         },
         "70019": {
             "Name": "Zoltan: Warrior",
-            "Info": "Deploy: Summon Figgis Merluzzo and Munro Bruys, boost them by the half value of Zotan's boost.",
+            "Info": "Deploy: Summon Figgis Merluzzo and Munro Bruys, then boost them by half the value of Zotan's boost.",
             "Flavor": ""
         },
         "70020": {
             "Name": "Figgis Merluzzo",
-            "Info": "Deploy: Summon Zoltan Warrior and Munro Bruys, boost them by the half value of Figgis' boost.",
+            "Info": "Deploy: Summon Zoltan Warrior and Munro Bruys, then boost them by half the value of Figgis' boost.",
             "Flavor": ""
         },
         "70021": {
             "Name": "Munro Bruys",
-            "Info": "Deploy: Summon Zoltan: Warrior and Figgis Merluzzo, boost them by the half value of Munro's boost.",
+            "Info": "Deploy: Summon Zoltan: Warrior and Figgis Merluzzo, then boost them by half the value of Munro's boost.",
             "Flavor": ""
         },
         "70022": {
             "Name": "Kikimore Worker",
-            "Info": "Deploy: Choose an \"Insectoid\" friendly unit, and boost all the cards with the same name on your side of the board, hand and deck by 2 points.",
+            "Info": "Deploy: Choose an Insectoid friendly unit, and boost all the cards with the same name on your side of the board, hand and deck by 2 points.",
             "Flavor": ""
         },
         "70023": {
             "Name": "Kikimore Warrior",
-            "Info": "Deploy: Consume a non-identical bronze unit card in your own deck with current power no greater than its own, and boost self by its power.",
+            "Info": "Deploy: Consume a non-identical Bronze unit in your own deck with current power no greater than its own, then boost self by its power.",
             "Flavor": ""
         },
         "70024": {
             "Name": "Cursed Immortals",
-            "Info": "When the adjacent cursed unit is destroyed, spawn a \"Specter\" on this row.",
+            "Info": "When an adjacent Cursed unit is destroyed, spawn a Specter on this row.",
             "Flavor": ""
         },
         "70025": {
             "Name": "Syanna",
-            "Info": "4 Armor. Repeat the Deploy ability of the next bronze or sliver loyal unit you play.",
+            "Info": "Single-use. Repeat the Deploy ability of the next Bronze or Silver loyal unit you play. 4 Armor.",
             "Flavor": "Your Majesty... The princess has been touched by the curse o' the Black Sun. There's no hope, I'm afraid..."
         },
         "70026": {
@@ -2948,17 +2948,17 @@
         },
         "70027": {
             "Name": "Geralt: Axii",
-            "Info": "Deploy: Replay a silver/bronze loyal unit from your opponent's side of the board and then move it back to opponent's side of the board",
+            "Info": "Deploy: Replay a Bronze or Silver loyal unit from your opponent's side of the board and then move it back to the opponent's side of the board",
             "Flavor": ""
         },
         "70032": {
             "Name": "Gascon",
-            "Info": "Deploy: Move all units to a random other row and damage self by 2 for each unit moved.\n\nWhen in your hand or deck, boost self by 1 whenever a unit moves during your turn.",
+            "Info": "Deploy: Move all units to a random other row and damage self by 2 for each unit moved.\nWhen in your hand or deck, boost self by 1 whenever a unit moves during your turn.",
             "Flavor": "“Th' Strays of Spalla – 'tis you who lead them? 'Tis you they call the Duke of Dogs?”"
         },
         "70033": {
             "Name": "War Elephant",
-            "Info": "Deploy: Destroy the armor of all units in placed row and damage a unit by the value of armor destroyed.",
+            "Info": "Deploy: Destroy the armor of all units in this row and damage a unit by the amount destroyed.",
             "Flavor": ""
         },
         "70038": {
@@ -2968,7 +2968,7 @@
         },
         "70039": {
             "Name": "Dire Wolf Claws",
-            "Info": "Deploy: Deal 4 damage to a random enemy unit. When discarded, trigger this ability and shuffle 2 \"Dire Wolf Warriors\" in your deck.",
+            "Info": "Deploy: Deal 4 damage to a random enemy unit. When discarded, trigger this ability and shuffle 2 Dire Wolf Warriors in your deck.",
             "Flavor": ""
         },
         "70040": {
@@ -2978,22 +2978,22 @@
         },
         "70041": {
             "Name": "Giga Scorpion Decoction",
-            "Info": "Damage the strongest enemy unit by 2 points. Repeat 4 times. For each \"White Raffard's Decoction\" in your graveyard, repeat once more.",
+            "Info": "Damage the strongest enemy unit by 2 points. Repeat 3 times. For each White Raffard's Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70042": {
             "Name": "White Raffard's Decoction",
-            "Info": "Boost the weakest ally unit by 2 points. Repeat 4 times. For each \"Giga Scorpion Decoction\" in your graveyard, repeat once more.",
+            "Info": "Boost the weakest ally unit by 2 points. Repeat 3 times. For each Giga Scorpion Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70043": {
             "Name": "Vernossiel's Commando",
-            "Info": "After you Swap this unit two times, summon it to a random row.",
+            "Info": "After you Swap this unit twice, summon it to a random row.",
             "Flavor": ""
         },
         "70044": {
             "Name": "Vernossiel",
-            "Info": "Deploy: Add 2 \"Vernossiel's Commandos\" to your deck and reduce their counter by 1.",
+            "Info": "Deploy: Add 2 Vernossiel's Commandos to your deck and reduce their counter by 1.",
             "Flavor": ""
         },
         "70045": {
@@ -3008,37 +3008,37 @@
         },
         "70050": {
             "Name": "MadCharge",
-            "Info": "Choose an ally that has Armor , Duel an enemy.",
+            "Info": "Choose an ally with Armor, that unit then Duels an enemy.",
             "Flavor": ""
         },
         "70054": {
             "Name": "Feign Death",
-            "Info": "Resurrect 2 bronze units with power higher than 5 points, and deal 4 damage to each of them.",
+            "Info": "Resurrect 2 Bronze units with power higher than 5 points, then deal 4 damage to each of them.",
             "Flavor": ""
         },
         "70058": {
             "Name": "Cave Troll",
-            "Info": "Deploy: Boost self by 4, and then boost an enemy by 4 points.",
+            "Info": "Deploy: Boost self by 4, then boost an enemy by 4 points.",
             "Flavor": ""
         },
         "70059": {
             "Name": "One-Eyed Betsy",
-            "Info": "At the beginning of the round, gain 3 points, and then boost the strongest emeny by 3 points.",
+            "Info": "At the beginning of the round, boost self by 3 points, then boost the strongest enemy by 3 points.",
             "Flavor": "准头是差了点，但力道确实没话说。"
         },
         "70062": {
             "Name": "Living Armor",
-            "Info": "Units in the same row take at most 5 points per damage.",
+            "Info": "Units in the same row take at most 5 points of damage.",
             "Flavor": "价钱是贵了点。但是你把节省下来的吃住都算进去，不出一百年就能回本！"
         },
         "70070": {
             "Name": "Highwaymen",
-            "Info": "Exhausted. If there are only bronze cards in your starting deck, spawn a 'Strays of Spalla' , and add two 'Strays of Spalla' to your deck.",
+            "Info": "Single-use. If there are only Bronze cards in your starting deck, spawn a Strays of Spalla, then add two Strays of Spalla to your deck.",
             "Flavor": "“商人？抹了。马匹？卖了。”"
         },
         "70071": {
             "Name": "StraysofSpalla",
-            "Info": "Exhausted. Check the 2 bronze unit cards in your own deck, and then play 1 of them.",
+            "Info": "Single-use. Look at 2 random Bronze units in your deck, then play one.",
             "Flavor": "“嗷，嗷，嗷嗷！”"
         },
         "70072": {
@@ -3048,37 +3048,37 @@
         },
         "70076": {
             "Name": "Congregation Cleric",
-            "Info": "Generate copies of all locked bronze, and set the strength of copies to 2. Whenever any bronze unit are locked during your turn, generate a copy of it with 2 strength in the same row.",
+            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base strenght to 2. Whenever any Bronze unit is locked during your turn, generate a copy of it with 2 base strength in the same row.",
             "Flavor": "“靠近点，羔羊，再近点。愿永恒之火温暖你的灵魂！”"
         },
         "70077": {
             "Name": "Firesworn Zealot",
-            "Info": "Every 4 turns, deal 2 damages to 4 random enemies at the end of the turn. Reduce the countdown by 1 for each locked unit on the board when played.",
+            "Info": "Every 4 turns, deal 2 damage to 4 random enemies at the end of the turn. Reduce the countdown by 1 for each locked unit on the board when played.",
             "Flavor": "“我的信仰无人能敌，亦如我的怒火！”"
         },
         "70078": {
             "Name": "Damnation",
-            "Info": "Summon two strongest bronze units from the deck to the same row, and then change their lock status.",
+            "Info": "Summon the two Highest Bronze units from the deck to the same row, then change their lock status.",
             "Flavor": "“呛死我了！就不能去别的地方烧吗？”"
         },
         "70091": {
             "Name": "Magic Lamp",
-            "Info": "At the start of the game, add 3 The Last Wishes to your deck ,then Discard self.",
+            "Info": "At the start of the game, add 3 The Last Wish to your deck, then Discard self.",
             "Flavor": "破译梦境中的过去和未来是非常困难的，即使对大师也是如此。"
         },
         "70102": {
-            "Name": "Detlaff: CrimsonCurse",
-            "Info": "Banish a bronze 'Beast' or 'Vampire' in your cemetery, and then choose one: cast 3 rows of 'Full Moon' in your field; or cast 3 rows of 'Blood Moon' in the opponent's field.",
+            "Name": "Detlaff: Crimson Curse",
+            "Info": "Deploy: Banish a Bronze Beast or Vampire unit from your graveyard, then Choose One: cast 3 rows of Full Moon on your side of the board; or cast 3 rows of Blood Moon on the opponent's side of the board.",
             "Flavor": ""
         },
         "70103": {
             "Name": "Artorius Vigo",
-            "Info": "Deploy: Discard a card, add a Bronze unit card from your start deck to your hand, and then reveal it.",
+            "Info": "Deploy: Discard a card, then add a Bronze unit from your starting deck to your hand and reveal it.",
             "Flavor": "“据说他创造出的幻象栩栩如生，连他自己都开始信了……”"
         },
         "70104": {
-            "Name": "LyrianLandsknecht",
-            "Info": "After round over，if this card is boosted，shuffle it back to the deck and keep most 10 boost.",
+            "Name": "Lyrian Landsknecht",
+            "Info": "At the end of the round，if this card is boosted，shuffle it back to the deck and keep at most 10 boost.",
             "Flavor": "“相信我，最好别去嘲笑他们傻里傻气的帽子。”"
         },
         "70105": {
@@ -3088,7 +3088,7 @@
         },
         "70106": {
             "Name": "Endrega Eggs",
-            "Info": "Deploy: Spawn 1 base copies on the left.\n\nDeathwish: Spawn an Endrega Larva in this row.\n\nAfter 3 turns, at the end of your turn, destroy self.",
+            "Info": "Deploy: Spawn 1 base copy on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of your turn, destroy self.",
             "Flavor": "If you find some it's best to burn the entire forest down. Then run as far away as you can."
         },
         "70107": {
@@ -3103,7 +3103,7 @@
         },
         "70109": {
             "Name": "Dwarven Chariot",
-            "Info": "Select 2 units and move them to this unit row. When this unit moves, boost random unit in the same row by 2.",
+            "Info": "Select 2 units and move them to this unit's row. When this unit is moved, boost a random unit in the same row by 2.",
             "Flavor": "“随你们怎么画，各位亲爱的矮人。但是我把话放在这里，它造不出来。”"
         },
         "130210": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -288,7 +288,7 @@
         },
         "12013": {
             "Name": "Lambert: Swordmaster",
-            "Info": "Deploy: Deal 4 Damage to all copies of an enemy unit.",
+            "Info": "Deploy: Deal 4 Damage to all copies of an enemy.",
             "Flavor": "Go teach your grandma to suck eggs."
         },
         "12014": {
@@ -308,12 +308,12 @@
         },
         "12017": {
             "Name": "Geralt: Professional",
-            "Info": "Deploy: Deal 4 Damage to an enemy unit.\nIf it's a Monster unit, destroy it instead.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf it's a Monster unit, destroy it instead.",
             "Flavor": "I accepted a job once, did it. Asked to choose my reward, I invoked the Law of Surprise."
         },
         "12018": {
             "Name": "Ihuarraquax",
-            "Info": "Deploy: Deal 5 Damage to self.\nThe first time this unit's current power is equal to its base power, on turn end, deal 7 Damage to 3 random enemy units.",
+            "Info": "Deploy: Deal 5 Damage to self.\nThe first time this unit's current power is equal to its base power, on turn end, deal 7 Damage to 3 random enemies.",
             "Flavor": "\"Inconceivable. Impossible\", Ciri thought, returning to her senses. \"Unicorns don't exist, not any more, not in this world. Unicorns are extinct.\" "
         },
         "12019": {
@@ -818,7 +818,7 @@
         },
         "15003": {
             "Name": "Shupe: Mage",
-            "Info": "Send Shupe to the Ban Ard Academy. Draw 1 card; Charm a random enemy unit; Spawn a random Hazard on all enemy rows; Deal 10 Damage to an enemy, then 5 Damage to adjacent units; Play a special card from your deck.",
+            "Info": "Send Shupe to the Ban Ard Academy. Draw 1 card; Charm a random enemy; Spawn a random Hazard on all enemy rows; Deal 10 Damage to an enemy, then 5 Damage to adjacent units; Play a special card from your deck.",
             "Flavor": "其他巨魔都觉得他是个异类，毕竟在巨魔们看来，谁会喜欢彩色纸片胜过喜欢石头呢？"
         },
         "15004": {
@@ -923,7 +923,7 @@
         },
         "22005": {
             "Name": "Imlerith",
-            "Info": "Deploy: Damage an Enemy by 4.\nIf the Enemy is under a Frost Hazard, Destory it instead. ",
+            "Info": "Deploy: Damage an enemy by 4.\nIf the enemy is under a Frost Hazard, Destory it instead. ",
             "Flavor": "叫他们有来无回！"
         },
         "22006": {
@@ -1598,7 +1598,7 @@
         },
         "34003": {
             "Name": "Impera Brigade",
-            "Info": "Deploy: Boost self by 2 for each Spying Enemy.\nWhenever a Spying Enemy appears, boost self by 2.",
+            "Info": "Deploy: Boost self by 2 for each Spying enemy.\nWhenever a Spying enemy appears, boost self by 2.",
             "Flavor": "近卫军绝不投降，绝不。"
         },
         "34005": {
@@ -1958,7 +1958,7 @@
         },
         "44014": {
             "Name": "Reinforced Ballista",
-            "Info": "Deploy: Damage an Enemy by 2. \nCrewed: Repeat its ability.",
+            "Info": "Deploy: Damage an enemy by 2. \nCrewed: Repeat its ability.",
             "Flavor": "从没两次命中同一处，仔细想想，真是个大问题。"
         },
         "44015": {
@@ -1973,7 +1973,7 @@
         },
         "44017": {
             "Name": "Ballista",
-            "Info": "Deploy: Damage an Enemy and up to 4 other random Enemies with the same Power by 1.\nCrewed: Repeat its ability.",
+            "Info": "Deploy: Damage an enemy and up to 4 other random Enemies with the same Power by 1.\nCrewed: Repeat its ability.",
             "Flavor": "成为弩炮是所有十字弩的终极梦想。"
         },
         "44018": {
@@ -2723,7 +2723,7 @@
         },
         "64026": {
             "Name": "Drummond Shieldmaid",
-            "Info": "Deploy: Deal 2 Damage to an enemy unit. If the target was already injured, play one copy from the deck.",
+            "Info": "Deploy: Deal 2 Damage to an enemy. If the target was already injured, play one copy from the deck.",
             "Flavor": "我们的敌人会像打上嶙峋海岸的波浪一样，倒在我们的盾前。"
         },
         "64027": {
@@ -2863,7 +2863,7 @@
         },
         "70009": {
             "Name": "Fleder",
-            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy unit becomes Damaged, boost self by 1.",
+            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy becomes Damaged, boost self by 1.",
             "Flavor": ""
         },
         "70010": {
@@ -2893,7 +2893,7 @@
         },
         "70015": {
             "Name": "Brokilon Sentinel",
-            "Info": "On round end, if the opponent has exactly 4 units in the opposing row, deal 1 Damage to all enemy units in that row.",
+            "Info": "On round end, if the opponent has exactly 4 units in the opposing row, deal 1 Damage to all enemies in that row.",
             "Flavor": ""
         },
         "70016": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -226,14 +226,14 @@
         "CardTag_Test": "Test",
         "ShupeKnight_1_Strengthen": "Strengthen self to 25.",
         "ShupeKnight_2_Resilience": "Resilient.",
-        "ShupeKnight_3_Duel": "Duel an enemy. ",
+        "ShupeKnight_3_Duel": "Duel an enemy.",
         "ShupeKnight_4_Reset": "Reset a unit.",
-        "ShupeKnight_5_Destroy": "Destroy enemies with less than 4 power.",
+        "ShupeKnight_5_Destroy": "Destroy enemies with less than 4 Power.",
         "ShupeHunter_1_SingleDamage": "Deal 15 Damage.",
-        "ShupeHunter_2_RepeatedDamage": "Deal 2 Damage to a random enemy. Repeat 8 times.",
-        "ShupeHunter_3_Replay": "Replay a Bronze or Silver ally and boost it by 5.",
-        "ShupeHunter_4_PlayFromDeck": "Play a Bronze or Silver unit from your deck",
-        "ShupeHunter_5_ClearSky": " Clear all Hazards from your side and boost allies by 1.",
+        "ShupeHunter_2_RepeatedDamage": "Deal 2 Damage to a random enemy.\nRepeat 8 times.",
+        "ShupeHunter_3_Replay": "Replay a Bronze or Silver ally and Boost it by 5.",
+        "ShupeHunter_4_PlayFromDeck": "Play a Bronze or Silver unit from your deck.",
+        "ShupeHunter_5_ClearSky": " Clear all Hazards from your side and Boost allies by 1.",
         "ShupeMage_1_DrawCard": "Draw a card.",
         "ShupeMage_2_Charm": "Charm a random enemy.",
         "ShupeMage_3_Hazard": "Spawn random Hazards on all enemy rows.",
@@ -248,7 +248,7 @@
         },
         "12005": {
             "Name": "Ciri: Dash",
-            "Info": "Whenever this unit enters the graveyard, return it to your deck and strengthen it by 3.",
+            "Info": "Whenever this unit enters the graveyard, return it to your deck and Strengthen it by 3.",
             "Flavor": "Know when fairy tales cease to be tales? When people start believing them."
         },
         "12006": {
@@ -278,7 +278,7 @@
         },
         "12011": {
             "Name": "Dandelion: Vainglory",
-            "Info": "Deploy: For every Geralt, Yennefer, Triss and Zoltan Gold card in your starting deck, boost self by 3.",
+            "Info": "Deploy: For every Geralt, Yennefer, Triss and Zoltan Gold card in your starting deck, Boost self by 3.",
             "Flavor": "Dandelion told me all about your adventures. How'd he ready you for battle with his songs, how he tamed the kayran by playin' his lute..."
         },
         "12012": {
@@ -293,17 +293,17 @@
         },
         "12014": {
             "Name": "Triss: Butterflies",
-            "Info": "On turn end, boost the Lowest allies by 1.",
+            "Info": "On turn end, Boost the Lowest allies by 1.",
             "Flavor": "Cap'n... our arrows, they've... they've got wings!"
         },
         "12015": {
             "Name": "Zoltan: Scoundrel",
-            "Info": "Deploy, Choose One: Spawn a Duda: Companion that boosts 2 units on each side of it by 2; or Spawn a Duda: Agitator that deals 2 Damage to 2 units on each side of it.",
+            "Info": "Deploy, Choose One: Spawn a Duda: Companion that Boosts 2 units on each side of it by 2; or Spawn a Duda: Agitator that deals 2 Damage to 2 units on each side of it.",
             "Flavor": "Apologies. My exotic pet's a clever birdie, but a wee bit lewd. Paid ten thalers for the beaute."
         },
         "12016": {
             "Name": "Eskel: Pathfinder",
-            "Info": "Deploy: Destroy a Bronze or Silver enemy that is not boosted.",
+            "Info": "Deploy: Destroy a Bronze or Silver enemy that is not Boosted.",
             "Flavor": "Heard you panting from three miles away. Just didn't wanna give up that vantage point."
         },
         "12017": {
@@ -313,7 +313,7 @@
         },
         "12018": {
             "Name": "Ihuarraquax",
-            "Info": "Deploy: Deal 5 Damage to self.\nThe first time this unit's current power is equal to its base power, on turn end, deal 7 Damage to 3 random enemies.",
+            "Info": "Deploy: Deal 5 Damage to self.\nThe first time this unit's current Power is equal to its base Power, on turn end, deal 7 Damage to 3 random enemies.",
             "Flavor": "\"Inconceivable. Impossible\", Ciri thought, returning to her senses. \"Unicorns don't exist, not any more, not in this world. Unicorns are extinct.\" "
         },
         "12019": {
@@ -323,7 +323,7 @@
         },
         "12020": {
             "Name": "Gaunter O'Dimm",
-            "Info": "Deploy, Gamble with Gaunter: Guess whether the power of the card he picked is less, equal or greater than 6.",
+            "Info": "Deploy, Gamble with Gaunter: Guess whether the Power of the card he picked is less, equal or greater than 6.",
             "Flavor": "He always grants exactly what you wish for. That's the problem."
         },
         "12021": {
@@ -333,7 +333,7 @@
         },
         "12022": {
             "Name": "Regis: Higher Vampire",
-            "Info": "Deploy: Look at 3 Bronze units from your opponent's deck.\nConsume 1, then boost self by its base power.",
+            "Info": "Deploy: Look at 3 Bronze units from your opponent's deck.\nConsume 1, then Boost self by its base Power.",
             "Flavor": "He becomes invisible at will. His glance hypnotizes into a deep sleep. He then drinks his fill, turns into a bat and flies off. Altogether uncouth."
         },
         "12023": {
@@ -343,7 +343,7 @@
         },
         "12024": {
             "Name": "Yennefer",
-            "Info": "Deploy, Choose One: Spawn a Unicorn that boosts all other units by 2; or Spawn a Chironex that deals 2 Damage to all other units.",
+            "Info": "Deploy, Choose One: Spawn a Unicorn that Boosts all other units by 2; or Spawn a Chironex that deals 2 Damage to all other units.",
             "Flavor": "Magic is Chaos, Art and Science. It is a curse, a blessing and a progression."
         },
         "12025": {
@@ -358,12 +358,12 @@
         },
         "12002": {
             "Name": "Geralt: Igni",
-            "Info": "Deploy: Destroy the Highest units on an enemy row if that row has a total of 25 or more.",
+            "Info": "Deploy: Destroy the Highest units on an enemy row if that row has a total of 25 points or more.",
             "Flavor": "A twist of a witcher's fingers can light a lamp… or incinerate a foe."
         },
         "12027": {
             "Name": "Aguara",
-            "Info": "Deploy, Choose Two: Boost the Lowest ally by 5; Boost a random unit in your hand by 5; Deal 5 Damage to the Highest enemy; Charm a random enemy Elf with 5 power or less.",
+            "Info": "Deploy, Choose Two: Boost the Lowest ally by 5; Boost a random unit in your hand by 5; Deal 5 Damage to the Highest enemy; Charm a random enemy Elf with 5 Power or less.",
             "Flavor": "Smarten up right now, or it's off to an aguara with you!"
         },
         "12028": {
@@ -388,13 +388,13 @@
         },
         "12031": {
             "Name": "Regis",
-            "Info": "Deploy: Drain all boosts from a unit.",
+            "Info": "Deploy: Drain all Boosts from a unit.",
             "Flavor": "Men, the polite ones, at least, would call me a monster. A blood–drinking freak."
         },
         "12032": {
             "Name": "Ciri: Nova",
-            "Info": "Deploy: If you have exactly 2 copies of each Bronze card in your starting deck, set the base power of this card to 22.",
-            "Flavor": "Zireael possesses a great power she cannot control. She is a danger - to herself, to others. Until she learns to control it, she should remain isolated."
+            "Info": "Deploy: If you have exactly 2 copies of each Bronze card in your starting deck, set the base Power of this card to 22.",
+            "Flavor": "Zireael possesses a great Power she cannot control. She is a danger - to herself, to others. Until she learns to control it, she should remain isolated."
         },
         "12033": {
             "Name": "Korathi Heatwave",
@@ -404,7 +404,7 @@
         "12034": {
             "Name": "Ragh Nar Roog",
             "Info": "Apply a Hazard to each enemy row that deals 2 Damage to the Highest unit on turn start.",
-            "Flavor": "In the Final Age, Hemdall will come forth to face the evil issuing from the land of Morhogg – the legions of wraiths, demons and specters of Chaos"
+            "Flavor": "In the Final Age, Hemdall will come forth to face the evil issuing from the land of Morhogg – the legions of wraiths, demons and specters of Chaos."
         },
         "12035": {
             "Name": "Renew",
@@ -413,22 +413,22 @@
         },
         "12001": {
             "Name": "Royal Decree",
-            "Info": "Play a Gold unit from your deck and boost it by 2.",
+            "Info": "Play a Gold unit from your deck and Boost it by 2.",
             "Flavor": "We, Foltest, by divine right King of Temeria, Prince of Sodden, Senior Protector of Brugge, etcetera, etcetera, do hereby decree the following.."
         },
         "12036": {
             "Name": "Vigo's Muzzle",
-            "Info": "Charm a Bronze or Silver enemy with 8 power or less.",
+            "Info": "Charm a Bronze or Silver enemy with 8 Power or less.",
             "Flavor": "Not every beast can be tamed. But all can be muzzled."
         },
         "12037": {
             "Name": "Wolfsbane",
-            "Info": "After 3 turns in the graveyard, on turn end, deal 6 Damage to the Highest enemy and boost the Lowest ally by 6.",
+            "Info": "After 3 turns in the graveyard, on turn end, deal 6 Damage to the Highest enemy and Boost the Lowest ally by 6.",
             "Flavor": "Also known as 'the queen of poisons,' wolfsbane is used in many witcher Potions and alchemic brews."
         },
         "12038": {
             "Name": "Hanmarvyn's Blue Dream",
-            "Info": "Spawn a copy of a non-Leader Gold unit from your opponent's graveyard and boost it by 2.",
+            "Info": "Spawn a copy of a non-Leader Gold unit from your opponent's graveyard and Boost it by 2.",
             "Flavor": "This spell lets you see the last moment's of a dead man's life... if you can survive its casting."
         },
         "12039": {
@@ -438,7 +438,7 @@
         },
         "12040": {
             "Name": "Trial of the Grasses",
-            "Info": "Deal 10 Damage to a unit, unless it's a Witcher.\nIf it survives, boost it to 25 power.",
+            "Info": "Deal 10 Damage to a unit, unless it's a Witcher.\nIf it survives, Boost it to 25 Power.",
             "Flavor": "Imagine a lump of clay. In order to shape it, you must first moisten it or it will crumble. The Trial's initial part does just that. It opens the body to change, so to speak. Only then can the mutagens produce a witcher."
         },
         "12041": {
@@ -448,7 +448,7 @@
         },
         "12042": {
             "Name": "Sihil",
-            "Info": "Choose One: Deal 3 Damage to all enemies with odd power; or Deal 3 Damage to all enemies with even power; or Play a random Bronze or Silver unit from your deck.",
+            "Info": "Choose One: Deal 3 Damage to all enemies with odd Power; or Deal 3 Damage to all enemies with even Power; or Play a random Bronze or Silver unit from your deck.",
             "Flavor": "\"What's written on this blade? That a curse?\" \"No. An insult.\" "
         },
         "13003": {
@@ -473,7 +473,7 @@
         },
         "13007": {
             "Name": "Stregobor",
-            "Info": "Single-Use.\nDeploy, Truce: Each player draws a unit and sets its power to 1.",
+            "Info": "Single-Use.\nDeploy, Truce: Each player draws a unit and sets its Power to 1.",
             "Flavor": "猎魔人见过看上去像议员的贼，见过看上去像乞丐的议员，也见过看上去像贼的国王。不过斯崔葛布的样子，就和大众心目中法师的形象没什么两样。"
         },
         "13008": {
@@ -553,7 +553,7 @@
         },
         "13021": {
             "Name": "Dudu",
-            "Info": "Deploy: Choose an enemy and copy its power.",
+            "Info": "Deploy: Choose an enemy and copy its Power.",
             "Flavor": "拟态怪有很多别名：易形怪、二重身、模仿怪……变形怪。"
         },
         "13022": {
@@ -563,7 +563,7 @@
         },
         "13023": {
             "Name": "Black Blood",
-            "Info": "Choose One: Create a Bronze Necrophage or Vampire and boost it by 2; or Destroy a Bronze or Silver Necrophage or Vampire.",
+            "Info": "Choose One: Create a Bronze Necrophage or Vampire and Boost it by 2; or Destroy a Bronze or Silver Necrophage or Vampire.",
             "Flavor": "吸血鬼们纷纷表示：使用这种药水有违体育精神。"
         },
         "13024": {
@@ -578,7 +578,7 @@
         },
         "13026": {
             "Name": "Bekker's Dark Mirror",
-            "Info": "Transfer up to 10 power between the Highest and Lowest unit.",
+            "Info": "Transfer up to 10 Power between the Highest and Lowest unit.",
             "Flavor": "当你凝视深渊的时候，深渊也在凝视着你。"
         },
         "13027": {
@@ -588,12 +588,12 @@
         },
         "13028": {
             "Name": "Decoy",
-            "Info": "Return a Bronze or Silver ally to your hand, boost it by 3 and play it.",
+            "Info": "Return a Bronze or Silver ally to your hand, Boost it by 3 and play it.",
             "Flavor": "如果拿来应急，假人也是不错的挡箭牌。"
         },
         "13029": {
             "Name": "Dimeritium Bomb",
-            "Info": "Reset all boosted units on a row.",
+            "Info": "Reset all Boosted units on a row.",
             "Flavor": "女巫猎人必备。无声的闪光过后，最强大的法师也得乖乖就擒。"
         },
         "13030": {
@@ -608,12 +608,12 @@
         },
         "13032": {
             "Name": "Merigold's Hailstorm",
-            "Info": "Halve the power of all Bronze and Silver units on a row.",
+            "Info": "Halve the Power of all Bronze and Silver units on a row.",
             "Flavor": "天空突然暗了下来，云层笼罩在城镇上空。愁云惨淡之中，寒风呼啸而过。“哦，我的天哪，”叶奈法吸了口气，“看起来你成功了……”"
         },
         "13033": {
             "Name": "Necromancy",
-            "Info": "Banish a Bronze or Silver unit from either graveyard, then boost an ally by its power.",
+            "Info": "Banish a Bronze or Silver unit from either graveyard, then Boost an ally by its Power.",
             "Flavor": "无论怎样……我们都有办法叫你开口。"
         },
         "13034": {
@@ -638,7 +638,7 @@
         },
         "13038": {
             "Name": "White Frost",
-            "Info": "Apply Biting Frost to 2 adjacent enemy rows. Biting Frost: Every turn, on turn start, Damage the Lowest unit on the row by 2.",
+            "Info": "Apply Biting Frost to a row and the one above it.\n(Every turn, on turn start, Damage the Lowest unit on the row by 2).",
             "Flavor": "见证“泰德戴尔瑞”——终焉纪元——这被白霜摧毀的世界吧！"
         },
         "13039": {
@@ -648,7 +648,7 @@
         },
         "13040": {
             "Name": "Mandrake",
-            "Info": "Choose One: Heal a unit and strengthen it by 6; or Reset a unit and Weaken it by 6.",
+            "Info": "Choose One: Heal a unit and Strengthen it by 6; or Reset a unit and Weaken it by 6.",
             "Flavor": "衮衮诸公，瞠目环立，不肯相信这高贵的发现。有的在谈曼陀罗花，有的又说是在用黑犬。"
         },
         "13041": {
@@ -658,7 +658,7 @@
         },
         "13042": {
             "Name": "Glorious Hunt",
-            "Info": "If losing, Spawn an Imperial Manticore. If winning or tied, Spawn Manticore Venom.",
+            "Info": "If losing, Spawn an Imperial Manticore.\nIf winning or tied, Spawn Manticore Venom.",
             "Flavor": "以诸神的名义，猎魔人，你把这鬼东西拿来干嘛？！“我要那畜生的脑袋！”这句话不过是打个比方！"
         },
         "13043": {
@@ -668,7 +668,7 @@
         },
         "13044": {
             "Name": "Garrison",
-            "Info": "Create a Bronze or Silver unit from your opponent's starting deck and boost it by 2.",
+            "Info": "Create a Bronze or Silver unit from your opponent's starting deck and Boost it by 2.",
             "Flavor": "咚咚咚，有人在家吗？"
         },
         "14002": {
@@ -728,7 +728,7 @@
         },
         "14013": {
             "Name": "Mardroeme",
-            "Info": "Choose One: Reset a unit and strengthen it by 3; or Reset a unit and Weaken it by 3.",
+            "Info": "Choose One: Reset a unit and Strengthen it by 3; or Reset a unit and Weaken it by 3.",
             "Flavor": "Carried by the wind across the Continent… Sowing madness and blight where they fall."
         },
         "14014": {
@@ -738,7 +738,7 @@
         },
         "14015": {
             "Name": "Wyvern Scale Shield",
-            "Info": "Boost a unit by the base power of a Bronze or Silver unit in your hand.",
+            "Info": "Boost a unit by the base Power of a Bronze or Silver unit in your hand.",
             "Flavor": "比一般的盾牌要坚固，而且更时髦。"
         },
         "14016": {
@@ -768,7 +768,7 @@
         },
         "14021": {
             "Name": "Crow's Eye",
-            "Info": "Deal 4 Damage to the Highest enemy on each row. Deal 1 extra Damage for each copy of this card in your graveyard.",
+            "Info": "Deal 4 Damage to the Highest enemy on each row.\nDeal 1 extra Damage for each copy of this card in your graveyard.",
             "Flavor": "某个大名鼎鼎的海盗曾经沉迷于这种迷人的药草，进而得名“乌鸦眼”。然而对于海盗故事十分讲究的人而言，他的这一段传说实在太不像话，自然也就没能流传下来。"
         },
         "14022": {
@@ -783,7 +783,7 @@
         },
         "14024": {
             "Name": "Mastercrafted Spear",
-            "Info": "Deal Damage equal to the base power of a Bronze or Silver unit in your hand.",
+            "Info": "Deal Damage equal to the base Power of a Bronze or Silver unit in your hand.",
             "Flavor": "把长矛立起来，懒虫！一匹马都不能放过去！"
         },
         "14001": {
@@ -798,7 +798,7 @@
         },
         "14026": {
             "Name": "Golden Froth",
-            "Info": "Apply a Boon to an allied row that boosts 2 random units by 1 on turn start.",
+            "Info": "Apply a Boon to an allied row that Boosts 2 random units by 1 on turn start.",
             "Flavor": "闻到了吗？那是幸福的味道。"
         },
         "14027": {
@@ -808,12 +808,12 @@
         },
         "15001": {
             "Name": "Shupe: Knight",
-            "Info": "Send Shupe to the Imperial Court Military Academy. Strengthen self to 25; Gain Resilience; Duel a unit; Reset a unit; Destroy all enemies with 4 power or less.",
+            "Info": "Send Shupe to the Imperial Court Military Academy. Strengthen self to 25; Gain Resilience; Duel a unit; Reset a unit; Destroy all enemies with 4 Power or less.",
             "Flavor": "其他巨魔都觉得他是个异类，毕竟在巨魔们看来，谁会喜欢彩色纸片胜过喜欢石头呢？"
         },
         "15002": {
             "Name": "Shupe: Hunter",
-            "Info": "Send Shupe to the forests of Dol Blathanna. Deal 15 Damage; Deal 2 Damage to a random enemy 8 times; Replay a Bronze or Silver unit and boost it by 5; Play a Bronze or Silver unit from your deck; Remove Hazards on your side of the board and boost your units by 1.",
+            "Info": "Send Shupe to the forests of Dol Blathanna. Deal 15 Damage; Deal 2 Damage to a random enemy 8 times; Replay a Bronze or Silver unit and Boost it by 5; Play a Bronze or Silver unit from your deck; Remove Hazards on your side of the board and Boost your units by 1.",
             "Flavor": "其他巨魔都觉得他是个异类，毕竟在巨魔们看来，谁会喜欢彩色纸片胜过喜欢石头呢？"
         },
         "15003": {
@@ -883,7 +883,7 @@
         },
         "21002": {
             "Name": "Arachas Queen",
-            "Info": "Deploy: Consume 3 allies and boost self by their power.\nImmune.",
+            "Info": "Deploy: Consume 3 allies and Boost self by their Power.\nImmune.",
             "Flavor": "她的孩子们完美继承了她的美貌。"
         },
         "21003": {
@@ -908,7 +908,7 @@
         },
         "22002": {
             "Name": "Draug",
-            "Info": "Deploy: Resurrect units as 1-power Draugirs until you fill this unit's row.",
+            "Info": "Deploy: Resurrect units as 1-Power Draugirs until you fill this unit's row.",
             "Flavor": "有些人就是不服输，死了还要继续打。"
         },
         "22003": {
@@ -923,7 +923,7 @@
         },
         "22005": {
             "Name": "Imlerith",
-            "Info": "Deploy: Damage an enemy by 4.\nIf the enemy is under a Frost Hazard, Destory it instead. ",
+            "Info": "Deploy: Damage an enemy by 4.\nIf the enemy is under a Frost Hazard, Destory it instead.",
             "Flavor": "叫他们有来无回！"
         },
         "22006": {
@@ -933,7 +933,7 @@
         },
         "22007": {
             "Name": "Kayran",
-            "Info": "Deploy: Consume a unit with 7 power or less and boost self by its power. ",
+            "Info": "Deploy: Consume a unit with 7 Power or less and Boost self by its Power.",
             "Flavor": "对付巨章鱼怪？简单。找出你最好的剑——卖了它，雇个猎魔人。"
         },
         "22008": {
@@ -968,7 +968,7 @@
         },
         "22014": {
             "Name": "Brewess: Ritual",
-            "Info": "Deploy: Resurrect 2 Bronze Deathwish units",
+            "Info": "Deploy: Resurrect 2 Bronze Deathwish units.",
             "Flavor": "切烂……剁碎……然后熬出……一锅好汤。"
         },
         "23001": {
@@ -1018,7 +1018,7 @@
         },
         "23010": {
             "Name": "Morvudd",
-            "Info": "Deploy: Toggle a unit's Lock status.\nIf it was an enemy, halve its power.",
+            "Info": "Deploy: Toggle a unit's Lock status.\nIf it was an enemy, halve its Power.",
             "Flavor": "一种只在大史凯利格出没的珍稀鹿首魔品种。对食物异乎寻常的挑剔。"
         },
         "23011": {
@@ -1028,7 +1028,7 @@
         },
         "23012": {
             "Name": "Toad Prince",
-            "Info": "Deploy: Draw a unit, then Consume a unit in your hand and boost self by its power.",
+            "Info": "Deploy: Draw a unit, then Consume a unit in your hand and Boost self by its Power.",
             "Flavor": "又大又坏又丑，住在下水道里。"
         },
         "23013": {
@@ -1043,7 +1043,7 @@
         },
         "23015": {
             "Name": "Ozzrel",
-            "Info": "Deploy: Consume a Bronze or Silver unit from either graveyard and boost self by its power.",
+            "Info": "Deploy: Consume a Bronze or Silver unit from either graveyard and Boost self by its Power.",
             "Flavor": "一些食腐生物袭击过人类后，便再也不满足于区区腐肉了……"
         },
         "23016": {
@@ -1053,7 +1053,7 @@
         },
         "23017": {
             "Name": "Mourntart",
-            "Info": "Deploy: Consume all Bronze and Silver units in your graveyard and boost self by 1 for each.",
+            "Info": "Deploy: Consume all Bronze and Silver units in your graveyard and Boost self by 1 for each.",
             "Flavor": "大部分墓穴巫婆以墓穴中刨出来的尸体为食。但有些也会潜入小屋，偷走孩子，残害大人。因此基本上没人愿意和她们成为邻居。"
         },
         "23018": {
@@ -1063,7 +1063,7 @@
         },
         "23019": {
             "Name": "She-Troll of Vergen",
-            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, Consume it and boost self by its base power",
+            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, Consume it and Boost self by its base Power",
             "Flavor": "着迷于精灵洋葱汤。"
         },
         "23020": {
@@ -1073,17 +1073,17 @@
         },
         "23021": {
             "Name": "Monster Nest",
-            "Info": "Spawn a Bronze Necrophage or Insectoid unit and boost it by 1.",
+            "Info": "Spawn a Bronze Necrophage or Insectoid unit and Boost it by 1.",
             "Flavor": "该死，这些怪物泛滥成灾……我们得找个猎魔人，不然大家都活不成。"
         },
         "23022": {
             "Name": "Parasite",
-            "Info": "Choose One: Deal 12 Damage to an enemy; or boost an ally by 12.",
+            "Info": "Choose One: Deal 12 Damage to an enemy; or Boost an ally by 12.",
             "Flavor": "确实引人注目。"
         },
         "24001": {
             "Name": "Cyclops",
-            "Info": "Deploy: Destroy an ally and deal its power as Damage.",
+            "Info": "Deploy: Destroy an ally and deal its Power as Damage.",
             "Flavor": "别盯着它的眼睛，他不喜欢那样……"
         },
         "24002": {
@@ -1138,7 +1138,7 @@
         },
         "24012": {
             "Name": "Forktail",
-            "Info": "Deploy: Consume 2 allies and boost self by their power.",
+            "Info": "Deploy: Consume 2 allies and Boost self by their Power.",
             "Flavor": "要想印叉尾龙上钩，得这样做：在地里打一根桩子，上头绑一只山羊，然后赶紧钻到旁边的灌木丛里藏起来。"
         },
         "24013": {
@@ -1153,12 +1153,12 @@
         },
         "24015": {
             "Name": "Wild Hunt Drakkar",
-            "Info": "Aura: Boost all Wild Hunt allies by 1",
+            "Info": "Aura: Boost all Wild Hunt allies by 1.",
             "Flavor": "鬼船纳吉尔法的船头劈开波浪，将海水破成两道。号角响彻天际，汉姆多尔站在燃烧的彩虹之上，迎接敌人的来犯。白霜降临，狂风和暴雨近在咫尺……"
         },
         "24016": {
             "Name": "Wild Hunt Warrior",
-            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf the enemy is destroyed or is under Biting Frost, boost self by 2.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf the enemy is destroyed or is under Biting Frost, Boost self by 2.",
             "Flavor": "白霜将至。"
         },
         "24017": {
@@ -1183,12 +1183,12 @@
         },
         "24021": {
             "Name": "Ice Giant",
-            "Info": "Deploy: For every Biting Frost on the board, boost self by 3. Every time a Biting Frost appears on the board, boost self by 3.",
+            "Info": "Deploy: For every Biting Frost on the board, Boost self by 3.\nEvery time a Biting Frost appears on the board, Boost self by 3.",
             "Flavor": "我这辈子只当过一次逃兵，就是碰上寒冰巨人那次——我一点也没觉得丢人。"
         },
         "24022": {
             "Name": "Vran Warrior",
-            "Info": "Deploy: Consume the unit to the right and boost self by its power.\nEvery 2 turns, on turn start, repeat its ability.",
+            "Info": "Deploy: Consume the unit to the right and Boost self by its Power.\nEvery 2 turns, on turn start, repeat its ability.",
             "Flavor": "他们静静地骑在马上，看起来很放松，但全副武装：宽头短矛、剑柄独特的剑、战斧以及锯齿长斧。"
         },
         "24023": {
@@ -1203,7 +1203,7 @@
         },
         "24025": {
             "Name": "Barbegazi",
-            "Info": "Deploy: Consume an ally and boost self by its power.\nResilient.",
+            "Info": "Deploy: Consume an ally and Boost self by its Power.\nResilient.",
             "Flavor": "岩洞中先前还和石头没什么两样的怪物，倏地瞪大眼睛，充满恶意地盯着他。"
         },
         "24026": {
@@ -1233,7 +1233,7 @@
         },
         "24031": {
             "Name": "Nekker",
-            "Info": "Whenever you Consume a card, boost this unit by 1 if in hand, deck or on board.\nDeathwish: Play a copy of this unit from your deck.",
+            "Info": "Whenever you Consume a card, Boost this unit by 1 if in hand, deck or on board.\nDeathwish: Play a copy of this unit from your deck.",
             "Flavor": "如果忽略它们会攻击人类的残酷事实，这些小家伙其实挺可爱的。"
         },
         "24032": {
@@ -1288,7 +1288,7 @@
         },
         "25004": {
             "Name": "Harpy Egg",
-            "Info": "When Consumed by another unit, boost that unit by an additional 5.\nDeathwish: Spawn a Harpy Hatchling on a random row.",
+            "Info": "When Consumed by another unit, Boost that unit by an additional 5.\nDeathwish: Spawn a Harpy Hatchling on a random row.",
             "Flavor": "鹰身女妖蛋卷，真是美味佳肴啊，好先生。但它也非常昂贵，您可能料得到，这些可怜的鸟儿并不愿跟自己的蛋分离。"
         },
         "25005": {
@@ -1298,7 +1298,7 @@
         },
         "25006": {
             "Name": "Lesser Ifrit",
-            "Info": "When Summoned, deal 1 Damage to a random enemy",
+            "Info": "When Summoned, deal 1 Damage to a random enemy.",
             "Flavor": "曾经有个法师觉得它们可爱，而他的命运催生了一句俗语：“不要玩火自焚。”"
         },
         "25007": {
@@ -1313,7 +1313,7 @@
         },
         "25009": {
             "Name": "Full Moon",
-            "Info": "Apply a Boon to an allied row that boosts a random Beast or Vampire by 2 on turn start.",
+            "Info": "Apply a Boon to an allied row that Boosts a random Beast or Vampire by 2 on turn start.",
             "Flavor": "满月的时候，梦魇便会从世界的各个角落匍匐而出。"
         },
         "31002": {
@@ -1333,7 +1333,7 @@
         },
         "31004": {
             "Name": "Usurper",
-            "Info": "Spying.\nDeploy: Create any Leader and boost it by 2.",
+            "Info": "Spying.\nDeploy: Create any Leader and Boost it by 2.",
             "Flavor": "王权怎能单凭出身的贵贱来随便决定？"
         },
         "32002": {
@@ -1348,7 +1348,7 @@
         },
         "32004": {
             "Name": "Stefan Skellen",
-            "Info": "Deploy: Choose a card from your deck, boost it by 5 and move it to the top of your deck.",
+            "Info": "Deploy: Choose a card from your deck, Boost it by 5 and move it to the top of your deck.",
             "Flavor": "我在我们未来皇后的脸上留下了伤疤，这是我最引以为傲的成就。"
         },
         "32005": {
@@ -1368,12 +1368,12 @@
         },
         "32008": {
             "Name": "Menno Coehoorn",
-            "Info": "Deploy: Damage an enemy by 4.\nIf it is Spying, destroy it. ",
+            "Info": "Deploy: Damage an enemy by 4.\nIf it is Spying, destroy it.",
             "Flavor": "细心的侦察分队比训练有素的军团更管用。"
         },
         "32009": {
             "Name": "Leo Bonhart",
-            "Info": "Deploy: Reveal one of your units and deal Damage equal to its base power to an enemy.",
+            "Info": "Deploy: Reveal one of your units and deal Damage equal to its base Power to an enemy.",
             "Flavor": "他就坐在那里，死盯着我，一言不发。他的眼睛，好像……鱼眼，没有眉毛，没有睫毛……活脱脱两颗水球包裹的黑石头。一片死寂中，他就那样凝视着我，这却比被痛打我一顿更让我不寒而栗。"
         },
         "32001": {
@@ -1388,7 +1388,7 @@
         },
         "32011": {
             "Name": "Letho: Kingslayer",
-            "Info": "Deploy, Choose One: Destroy an enemy Leader, then boost self by 5; or play a Bronze or Silver Tactic from your deck.",
+            "Info": "Deploy, Choose One: Destroy an enemy Leader, then Boost self by 5; or play a Bronze or Silver Tactic from your deck.",
             "Flavor": "这僧侣为什么戴着镶钉手套……？"
         },
         "32012": {
@@ -1403,7 +1403,7 @@
         },
         "32014": {
             "Name": "Letho of Gulet",
-            "Info": "Double agent.\nDeploy: Toggle 2 units' Lock on the same row, then Drain all their power.",
+            "Info": "Double agent.\nDeploy: Toggle 2 units' Lock on the same row, then Drain all their Power.",
             "Flavor": "猎魔人绝不会死在自己的床上。"
         },
         "32015": {
@@ -1438,12 +1438,12 @@
         },
         "33008": {
             "Name": "Henry var Attre",
-            "Info": "Deploy: Conceal any number of units.\nIf allies, boost by 2.\nIf enemies, deal 2 Damage.",
+            "Info": "Deploy: Conceal any number of units.\nIf allies, Boost by 2.\nIf enemies, deal 2 Damage.",
             "Flavor": "我在诺维格瑞驻守了十三年，什么我没见过？残忍、讥嘲、贪欲。可如今发生的事情却让我极度不安"
         },
         "33002": {
             "Name": "False Ciri",
-            "Info": "Spying.\nIf Spying, boost self by 1 on turn start and when your opponent passes, move to the opposite row.\nDeathwish: Destroy the Lowest unit on the row.",
+            "Info": "Spying.\nIf Spying, Boost self by 1 on turn start and when your opponent passes, move to the opposite row.\nDeathwish: Destroy the Lowest unit on the row.",
             "Flavor": "“她来了，”他心想，“皇帝的联姻对象。冒牌公主、冒牌的辛特拉女王、冒牌的雅鲁加河口统治者，也是帝国未来的命脉。”"
         },
         "33009": {
@@ -1458,7 +1458,7 @@
         },
         "33011": {
             "Name": "Peter Saar Gwynleve",
-            "Info": "Deploy, Choose One: Reset an ally and strengthen it by 3; or Reset an enemy and Weaken it by 3.",
+            "Info": "Deploy, Choose One: Reset an ally and Strengthen it by 3; or Reset an enemy and Weaken it by 3.",
             "Flavor": "这双手不属于什么“阁下”，只属于一介农夫。所以这是农夫与农夫间的对话。"
         },
         "33012": {
@@ -1468,17 +1468,17 @@
         },
         "33013": {
             "Name": "Cynthia",
-            "Info": "Deploy: Reveal the Highest unit in your opponent's hand and boost self by its power.",
+            "Info": "Deploy: Reveal the Highest unit in your opponent's hand and Boost self by its Power.",
             "Flavor": "决不能轻视辛西亚，必须把她看紧点儿。"
         },
         "33001": {
             "Name": "Joachim de Wett",
-            "Info": "Spying.\nDeploy: Play the top non-Spying Bronze or Silver unit from your deck and boost it by 10.",
+            "Info": "Spying.\nDeploy: Play the top non-Spying Bronze or Silver unit from your deck and Boost it by 10.",
             "Flavor": "即便用“无能”来形容德·维特公爵对维登集团军的领导，都算给他面子"
         },
         "33014": {
             "Name": "Vrygheff",
-            "Info": "Deploy: Play a Bronze Machine from your deck",
+            "Info": "Deploy: Play a Bronze Machine from your deck.",
             "Flavor": "以眼还眼，我们最后一定会全都变成瞎子。"
         },
         "33015": {
@@ -1498,7 +1498,7 @@
         },
         "33018": {
             "Name": "Fringilla Vigo",
-            "Info": "Double agent.\nDeploy: Copy the power from the unit to the left to the unit to the right.",
+            "Info": "Double agent.\nDeploy: Copy the Power from the unit to the left to the unit to the right.",
             "Flavor": "魔法的价值高于一切，高于所有争论和敌意。"
         },
         "33019": {
@@ -1518,12 +1518,12 @@
         },
         "33022": {
             "Name": "Nilfgaardian Gate",
-            "Info": "Play a Bronze or Silver Officer from your deck and boost it by 1.",
+            "Info": "Play a Bronze or Silver Officer from your deck and Boost it by 1.",
             "Flavor": "应该不会对游客开放……"
         },
         "33023": {
             "Name": "Slave Driver",
-            "Info": "Deploy: Set an ally's power to 1 and deal Damage to an enemy by the amount of power lost.",
+            "Info": "Deploy: Set an ally's Power to 1 and deal Damage to an enemy by the amount of Power lost.",
             "Flavor": "奴隶贩子只有一个追求：那就是把他的命令一丝不苟地执行下去。"
         },
         "34004": {
@@ -1563,22 +1563,22 @@
         },
         "34012": {
             "Name": "Slave Hunter",
-            "Info": "Deploy: Charm a Bronze enemy with 3 power or less.",
+            "Info": "Deploy: Charm a Bronze enemy with 3 Power or less.",
             "Flavor": "诀窍在于摧残他们的意志，而不是肉体"
         },
         "34013": {
             "Name": "Sentry",
-            "Info": "Deploy: Boost all copies of a Soldier by 2",
+            "Info": "Deploy: Boost all copies of a Soldier by 2.",
             "Flavor": "要造桥，不要造城墙。"
         },
         "34014": {
             "Name": "Alba Armored Cavalry",
-            "Info": "Whenever an ally appears, boost self by 1.",
+            "Info": "Whenever an ally appears, Boost self by 1.",
             "Flavor": "他们以雷动之势冲进敌军方阵，犹如一把尖刀插入柔软的肚腹。阿尔巴之师所向披靡，一路横扫，直取泰莫利亚步兵团的咽喉。"
         },
         "34015": {
             "Name": "Deithwen Arbalest",
-            "Info": "Deploy: Deal 4 Damage to an enemy. If it is Spying, deal 8 Damage instead.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf it is Spying, deal 8 Damage instead.",
             "Flavor": "我只瞄膝盖，一向如此。"
         },
         "34016": {
@@ -1588,7 +1588,7 @@
         },
         "34017": {
             "Name": "Nauzicaa Sergeant",
-            "Info": "Deploy: Clear Hazards from its row and boost an ally or a Revealed unit by 3.",
+            "Info": "Deploy: Clear Hazards from its row and Boost an ally or a Revealed unit by 3.",
             "Flavor": "皇帝会教北方人懂点儿规矩的。"
         },
         "34018": {
@@ -1598,7 +1598,7 @@
         },
         "34003": {
             "Name": "Impera Brigade",
-            "Info": "Deploy: Boost self by 2 for each Spying enemy.\nWhenever a Spying enemy appears, boost self by 2.",
+            "Info": "Deploy: Boost self by 2 for each Spying enemy.\nWhenever a Spying enemy appears, Boost self by 2.",
             "Flavor": "近卫军绝不投降，绝不。"
         },
         "34005": {
@@ -1613,12 +1613,12 @@
         },
         "34020": {
             "Name": "Nauzicaa Brigade",
-            "Info": "Deploy: Damage a Spying unit by 7.\nIf it was destroyed, strengthen self by 4.",
+            "Info": "Deploy: Damage a Spying unit by 7.\nIf it was destroyed, Strengthen self by 4.",
             "Flavor": "我们被称作死神头。想知道为什么吗？"
         },
         "34021": {
             "Name": "Spotter",
-            "Info": "Deploy: Choose a Bronze or Silver Revealed unit in either hand and boost self by its base power.",
+            "Info": "Deploy: Choose a Bronze or Silver Revealed unit in either hand and Boost self by its base Power.",
             "Flavor": "北方佬耍不出花招了。"
         },
         "34022": {
@@ -1638,7 +1638,7 @@
         },
         "34025": {
             "Name": "Imperial Golem",
-            "Info": "Summon a copy of this unit whenever you Reveal a card in your opponent's hand. ",
+            "Info": "Summon a copy of this unit whenever you Reveal a card in your opponent's hand.",
             "Flavor": "尼弗迦德最强大的法师们终于成功掌握了制造魔像的方法。更棒的是，他们已经“偶尔”能让这些魔像为帝国而战了……"
         },
         "34026": {
@@ -1678,7 +1678,7 @@
         },
         "34031": {
             "Name": "Venendal Elite",
-            "Info": "Deploy: Switch this unit's power with that of a Revealed unit.",
+            "Info": "Deploy: Switch this unit's Power with that of a Revealed unit.",
             "Flavor": "艾宾以其顶尖的雇佣兵和轻骑兵闻名天下。"
         },
         "34032": {
@@ -1688,7 +1688,7 @@
         },
         "34033": {
             "Name": "Ointment",
-            "Info": "Resurrect a Bronze unit with 5 power or less.",
+            "Info": "Resurrect a Bronze unit with 5 Power or less.",
             "Flavor": "它管用吗？谁知道呢。反正试试也没坏处。可能吧。"
         },
         "35001": {
@@ -1728,7 +1728,7 @@
         },
         "42002": {
             "Name": "Bloody Baron",
-            "Info": "Whenever an enemy is destroyed, if in hand, deck, or on board, boost self by 1.",
+            "Info": "Whenever an enemy is destroyed, if in hand, deck, or on board, Boost self by 1.",
             "Flavor": "我知道自己不是个好父亲，但……现在弥补或许还来得及。"
         },
         "42003": {
@@ -1803,7 +1803,7 @@
         },
         "43004": {
             "Name": "Ronvid the Incessant",
-            "Info": "On turn end, resurrect on a random row with 1 power.\nCrew.",
+            "Info": "On turn end, resurrect on a random row with 1 Power.\nCrew.",
             "Flavor": "这位自封的骑士四海漂泊，捍卫着心爱少女比贝莉的荣誉。虽然没人知道她住在哪里，她是不是哈活着，甚至是不是曾经有过这个人。"
         },
         "43005": {
@@ -1823,17 +1823,17 @@
         },
         "43008": {
             "Name": "Vincent Meis",
-            "Info": "Deploy: Destroy the Armor of all units, then boost self by half the value destroyed.",
+            "Info": "Deploy: Destroy the Armor of all units, then Boost self by half the value destroyed.",
             "Flavor": "白天是维吉玛城卫兵队长。到了晚上，便化身为无情的复仇者，保卫受尽压迫的劳苦大众。"
         },
         "43009": {
             "Name": "Odrin",
-            "Info": "On turn start, move to a random row and boost all allies on it by 1.\nDeathwish: boost all allies on the same row by 1.",
+            "Info": "On turn start, move to a random row and Boost all allies on it by 1.\nDeathwish: Boost all allies on the same row by 1.",
             "Flavor": "喝酒少了欧德林，就像划船没带桨。"
         },
         "43010": {
             "Name": "Hubert Rejk",
-            "Info": "Deploy: Drain all boosts from units in your deck.",
+            "Info": "Deploy: Drain all Boosts from units in your deck.",
             "Flavor": "验尸官是个冷静、淡定的人。就算是尸体，也会精心照料。"
         },
         "43011": {
@@ -1843,7 +1843,7 @@
         },
         "43012": {
             "Name": "Lubberkin",
-            "Info": "Deploy: Summon a Botchling",
+            "Info": "Deploy: Summon a Botchling.",
             "Flavor": "吾为汝取名蒂雅，收汝为吾女。"
         },
         "43013": {
@@ -1868,7 +1868,7 @@
         },
         "43017": {
             "Name": "Sabrina Glevissig",
-            "Info": "Spying.\nDeathwish: Set the power of all units on the row to the power of the Lowest unit on the row.",
+            "Info": "Spying.\nDeathwish: Set the Power of all units on the row to the Power of the Lowest unit on the row.",
             "Flavor": "科德温荒野之女。"
         },
         "43018": {
@@ -1908,7 +1908,7 @@
         },
         "44004": {
             "Name": "Kaedweni Cavalry",
-            "Info": "Deploy: Destroy a unit's Armor, then boost self by the amount destroyed.",
+            "Info": "Deploy: Destroy a unit's Armor, then Boost self by the amount destroyed.",
             "Flavor": "我一直很好奇，这帮家伙是怎么解决内急的？"
         },
         "44005": {
@@ -1918,7 +1918,7 @@
         },
         "44006": {
             "Name": "Redanian Elite",
-            "Info": "Whenever this unit's Armor reaches 0, boost self by 5.\n4 Armor.",
+            "Info": "Whenever this unit's Armor reaches 0, Boost self by 5.\n4 Armor.",
             "Flavor": "为了瑞达尼亚，不论上刀山下油锅，还是吃虫子，我都在所不惜。"
         },
         "44007": {
@@ -1943,22 +1943,22 @@
         },
         "44011": {
             "Name": "Siege Support",
-            "Info": "Whenever an ally appears, boost it by 1. If it's a Machine, also give it 1 Armor.\nCrew.",
+            "Info": "Whenever an ally appears, Boost it by 1. If it's a Machine, also give it 1 Armor.\nCrew.",
             "Flavor": "“你得把准星左校5度。”“把什么调多少？”"
         },
         "44012": {
             "Name": "Redanian Knight",
-            "Info": "On turn end, if this unit has no Armor, boost it by 2 and give it 2 Armor.",
+            "Info": "On turn end, if this unit has no Armor, Boost it by 2 and give it 2 Armor.",
             "Flavor": "为了荣耀，为了拉多维德陛下！"
         },
         "44013": {
             "Name": "Redanian Knight-Elect",
-            "Info": "On turn end, if this unit has Armor, boost adjacent units by 1.\n2 Armor.",
+            "Info": "On turn end, if this unit has Armor, Boost adjacent units by 1.\n2 Armor.",
             "Flavor": "不为名不为利，高尚的动机才能成就英雄！"
         },
         "44014": {
             "Name": "Reinforced Ballista",
-            "Info": "Deploy: Damage an enemy by 2. \nCrewed: Repeat its ability.",
+            "Info": "Deploy: Damage an enemy by 2.\nCrewed: Repeat its ability.",
             "Flavor": "从没两次命中同一处，仔细想想，真是个大问题。"
         },
         "44015": {
@@ -2023,12 +2023,12 @@
         },
         "44027": {
             "Name": "Blue Stripe Commando",
-            "Info": "Whenever a different Temerian ally with the same power is played, Summon a copy of this unit from your deck.",
+            "Info": "Whenever a different Temerian ally with the same Power is played, Summon a copy of this unit from your deck.",
             "Flavor": "我愿为泰莫利亚赴汤蹈火，不过大多时候是在排除异己。"
         },
         "44028": {
             "Name": "Blue Stripe Scout",
-            "Info": "Deploy: Boost all Temerian allies and your non-Spying Temerian units in hand and deck with the same power as this unit by 1.\nCrew.",
+            "Info": "Deploy: Boost all Temerian allies and your non-Spying Temerian units in hand and deck with the same Power as this unit by 1.\nCrew.",
             "Flavor": "蓝衣铁卫与松鼠党有个共通点——满心仇恨。"
         },
         "44029": {
@@ -2053,7 +2053,7 @@
         },
         "44033": {
             "Name": "Winch",
-            "Info": "Choose One: Resurrect a Bronze Machine and add the Doomed category to it; or boost all Machines on your side of the board by 3.",
+            "Info": "Choose One: Resurrect a Bronze Machine and add the Doomed category to it; or Boost all Machines on your side of the board by 3.",
             "Flavor": "就是一个绞盘。没什么可大惊小怪的。"
         },
         "44034": {
@@ -2078,7 +2078,7 @@
         },
         "51001": {
             "Name": "Francesca Findabair",
-            "Info": "Deploy: Swap a card with one of your choice and boost it by 3.",
+            "Info": "Deploy: Swap a card with one of your choice and Boost it by 3.",
             "Flavor": "世上没有轻而易举的和平，人类的压迫终将画下残酷的句点。"
         },
         "51002": {
@@ -2108,7 +2108,7 @@
         },
         "52003": {
             "Name": "Xavier Moran",
-            "Info": "Deploy: Boost this unit by the starting power of the Dwarf with the strongest starting power you played this round.",
+            "Info": "Deploy: Boost this unit by the starting Power of the Dwarf with the strongest starting Power you played this round.",
             "Flavor": "怎么了，公主？吃不惯野味吗？嗯？"
         },
         "52004": {
@@ -2128,7 +2128,7 @@
         },
         "52007": {
             "Name": "Iorveth",
-            "Info": "Deploy: Deal 8 Damage to an enemy.\nIf the unit was destroyed, boost all Elves in your hand by 1.",
+            "Info": "Deploy: Deal 8 Damage to an enemy.\nIf the unit was destroyed, Boost all Elves in your hand by 1.",
             "Flavor": "国王还是乞丐于我并无差别，人类少一个算一个。"
         },
         "52008": {
@@ -2168,7 +2168,7 @@
         },
         "53002": {
             "Name": "Ele'yas",
-            "Info": "Whenever you draw this unit or return it to your deck, boost self by 2.",
+            "Info": "Whenever you draw this unit or return it to your deck, Boost self by 2.",
             "Flavor": "只要出于爱，疯狂就是合理的。"
         },
         "53003": {
@@ -2178,7 +2178,7 @@
         },
         "53004": {
             "Name": "Sheldon Skaggs",
-            "Info": "Deploy: Move all allies on this unit's row to random rows and boost self by 1 for each.",
+            "Info": "Deploy: Move all allies on this unit's row to random rows and Boost self by 1 for each.",
             "Flavor": "我可是在战况最激烈的前线！"
         },
         "53005": {
@@ -2193,12 +2193,12 @@
         },
         "53007": {
             "Name": "Yarpen Zigrin",
-            "Info": "Whenever a Dwarf ally appears, boost self by 1.\nResilience.",
+            "Info": "Whenever a Dwarf ally appears, Boost self by 1.\nResilience.",
             "Flavor": "听说过巨龙奥克维斯塔吗？石英山那只？亚尔潘·齐格林与他的矮人同伴们把它解决了。"
         },
         "53008": {
             "Name": "Malena",
-            "Info": "Ambush: After 2 turns, on turn start, flip over and Charm the Highest Bronze or Silver enemy with 5 power or less.",
+            "Info": "Ambush: After 2 turns, on turn start, flip over and Charm the Highest Bronze or Silver enemy with 5 Power or less.",
             "Flavor": "我恨你们，人类。你们全都一个样。"
         },
         "53009": {
@@ -2208,12 +2208,12 @@
         },
         "53010": {
             "Name": "Braenn",
-            "Info": "Deploy: Deal Damage equal to this unit's power to an enemy.\nIf a unit was destroyed, boost all your other Dryads and Ambush units in hand, deck, and on board by 1.",
+            "Info": "Deploy: Deal Damage equal to this unit's Power to an enemy.\nIf a unit was destroyed, Boost all your other Dryads and Ambush units in hand, deck, and on board by 1.",
             "Flavor": "莫娜？不，不。我是布蕾恩。布洛克莱昂的女儿。"
         },
         "53011": {
             "Name": "Toruviel",
-            "Info": "Ambush: When your opponent passes, turn this unit over and boost 2 units on each side by 2.",
+            "Info": "Ambush: When your opponent passes, turn this unit over and Boost 2 units on each side by 2.",
             "Flavor": "我很乐意站在你面前，直视你的双眼然后干掉你……但你臭死了，人类。"
         },
         "53012": {
@@ -2288,17 +2288,17 @@
         },
         "54005": {
             "Name": "Dwarven Mercenary",
-            "Info": "Deploy: Move a unit to this row on its side.\nIf it's an ally, boost it by 3.",
+            "Info": "Deploy: Move a unit to this row on its side.\nIf it's an ally, Boost it by 3.",
             "Flavor": "工作就该既有趣又赚钱——比如拿悬赏换金子。"
         },
         "54006": {
             "Name": "Farseer",
-            "Info": "If a different ally or unit in your hand is boosted during your turn, boost self by 2 at the end of the turn.",
+            "Info": "If a different ally or unit in your hand is Boosted during your turn, Boost self by 2 at the end of the turn.",
             "Flavor": "有时候，他的话语听似令人费解，但其中总是蕴藏着深邃的道理和惊人的智慧。"
         },
         "54007": {
             "Name": "Vrihedd Dragoon",
-            "Info": "On turn end, boost a random loyal unit in your hand by 1.",
+            "Info": "On turn end, Boost a random loyal unit in your hand by 1.",
             "Flavor": "我见过的最可怕的场景？卡特利欧纳瘟疫、范格堡被夷为平地，还有维里赫德旅骑兵的冲锋。"
         },
         "54008": {
@@ -2313,7 +2313,7 @@
         },
         "54010": {
             "Name": "Hawker Smuggler",
-            "Info": "Whenever an enemy appears, boost self by 1.",
+            "Info": "Whenever an enemy appears, Boost self by 1.",
             "Flavor": "谁付的钱多我就给谁卖命，不然就挑个最容易抢的去抢。"
         },
         "54011": {
@@ -2323,7 +2323,7 @@
         },
         "54012": {
             "Name": "Mahakam Marauder",
-            "Info": "Whenever this unit is boosted, Damaged, strengthened or Weakened, boost it by 2.",
+            "Info": "Whenever this unit is Boosted, Damaged, Strengthened or Weakened, Boost it by 2.",
             "Flavor": "在玛哈坎崎岖的悬崖峭壁上狩猎可不是件简单事……但矮人们也从不轻易向危险低头。"
         },
         "54013": {
@@ -2338,7 +2338,7 @@
         },
         "54015": {
             "Name": "Dwarven Skirmisher",
-            "Info": "Deploy: Deal 3 Damage to an enemy.\nIf the unit was not destroyed, boost self by 3.",
+            "Info": "Deploy: Deal 3 Damage to an enemy.\nIf the unit was not destroyed, Boost self by 3.",
             "Flavor": "我跟十字镐打了一辈子交道，动动斧头算什么问题？"
         },
         "54016": {
@@ -2363,12 +2363,12 @@
         },
         "54020": {
             "Name": "Vrihedd Officer",
-            "Info": "Deploy: Swap a card and boost self by its base power.",
+            "Info": "Deploy: Swap a card and Boost self by its base Power.",
             "Flavor": "“仇恨之火比地狱烈焰更猛烈，比任何伤口都更刻骨铭心。”"
         },
         "54021": {
             "Name": "Elven Swordmaster",
-            "Info": "Deploy: Deal Damage equal to this unit's power.",
+            "Info": "Deploy: Deal Damage equal to this unit's Power.",
             "Flavor": "战斗如同舞蹈，千万不能让你的对手领舞。"
         },
         "54022": {
@@ -2388,7 +2388,7 @@
         },
         "54025": {
             "Name": "Blue Mountain Elite",
-            "Info": "Deploy: Summon all copies of this unit.\nWhenever this unit moves, boost self by 2.",
+            "Info": "Deploy: Summon all copies of this unit.\nWhenever this unit moves, Boost self by 2.",
             "Flavor": "听到他们奔袭的动静时，想跑已来不及了……"
         },
         "54026": {
@@ -2398,7 +2398,7 @@
         },
         "54027": {
             "Name": "Dol Blathanna Sentry",
-            "Info": "If in hand, deck or on board, boost self by 1 whenever you play a special card.",
+            "Info": "If in hand, deck or on board, Boost self by 1 whenever you play a special card.",
             "Flavor": "只要我们一息尚存，就绝不容许人类践踏多尔·布雷坦纳的绿荫。"
         },
         "54028": {
@@ -2453,7 +2453,7 @@
         },
         "62005": {
             "Name": "Wild Boar of the Sea",
-            "Info": "On turn end, strengthen the unit to the left by 1, then deal 1 Damage to the unit to the right.\n5 Armor.",
+            "Info": "On turn end, Strengthen the unit to the left by 1, then deal 1 Damage to the unit to the right.\n5 Armor.",
             "Flavor": "只消对尼弗迦德人提起这个名字，他们就会吓得尿裤子……"
         },
         "62006": {
@@ -2463,12 +2463,12 @@
         },
         "62007": {
             "Name": "Cerys an Craite",
-            "Info": "When 4 units are resurrected while this unit is in the graveyard, resurrect it and Strenghten it by 1.",
+            "Info": "When 4 units are resurrected while this unit is in the graveyard, resurrect it and Strengthen it by 1.",
             "Flavor": "大家叫我小雀鹰，知道为什么吗？因为我专治你这种鼠辈。"
         },
         "62008": {
             "Name": "Madman Lugos",
-            "Info": "Deploy: Discard a Bronze unit from your deck and Damage a unit by the Discarded unit's base power.",
+            "Info": "Deploy: Discard a Bronze unit from your deck and Damage a unit by the Discarded unit's base Power.",
             "Flavor": "哇哇哇哇哇哇啊！！！！"
         },
         "62009": {
@@ -2508,7 +2508,7 @@
         },
         "63003": {
             "Name": "Djenge Frett",
-            "Info": "Deploy: Deal 1 Damage to 2 allies and strengthen self by 2 for each.",
+            "Info": "Deploy: Deal 1 Damage to 2 allies and Strengthen self by 2 for each.",
             "Flavor": "如果通缉令上写着“无论死活”，绝大多数赏金猎人会直接快刀斩乱麻。但我不会。如果被我抓到，我会把人吊起来挠痒，让他笑到岔气。"
         },
         "63004": {
@@ -2533,7 +2533,7 @@
         },
         "63008": {
             "Name": "Giant Boar",
-            "Info": "Deploy: Destroy a random ally, then boost self by 10.",
+            "Info": "Deploy: Destroy a random ally, then Boost self by 10.",
             "Flavor": "如果在林子里捡到一头硕大的野猪，大多数人会尿了裤子，手忙脚乱地朝最近的树上爬。史凯利格人不会。他们反回两眼发直，大流口水。"
         },
         "63009": {
@@ -2548,7 +2548,7 @@
         },
         "63011": {
             "Name": "Holger Blackhand",
-            "Info": "Deploy: Deal 7 Damage.\nIf the unit was destroyed, strengthen the Highest unit in your graveyard by 3.",
+            "Info": "Deploy: Deal 7 Damage.\nIf the unit was destroyed, Strengthen the Highest unit in your graveyard by 3.",
             "Flavor": "敬尼弗迦德皇帝，祝他不得善终！"
         },
         "63012": {
@@ -2558,12 +2558,12 @@
         },
         "63013": {
             "Name": "Yoana",
-            "Info": "Deploy: Heal an ally, then boost it by the amount Healed.",
+            "Info": "Deploy: Heal an ally, then Boost it by the amount Healed.",
             "Flavor": "没人会把我当成一名老练的盔甲师傅。只是一个人类，而且还是个女人。可是矮人铁匠就不同了……"
         },
         "63014": {
             "Name": "Derran",
-            "Info": "Whenever an enemy is Damaged, boost this unit by 1.",
+            "Info": "Whenever an enemy is Damaged, Boost this unit by 1.",
             "Flavor": "能引发这样的疯狂，相比是极其可怖的……"
         },
         "63015": {
@@ -2588,12 +2588,12 @@
         },
         "63019": {
             "Name": "Restore",
-            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base power to 8.\nThen play a card.",
+            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base Power to 8.\nThen play a card.",
             "Flavor": "那些该死的女术士又抢咱们的风头！只要几个年轻姑娘挥挥手就能解决的话，谁还选择这么费时费力的办法？"
         },
         "63020": {
             "Name": "Ornamental Sword",
-            "Info": "Create a Bronze or Silver Skellige Soldier and strengthen it by 3.",
+            "Info": "Create a Bronze or Silver Skellige Soldier and Strengthen it by 3.",
             "Flavor": "看上去很精美，但顶多也就只能用来抹抹黄油。"
         },
         "64001": {
@@ -2638,7 +2638,7 @@
         },
         "64009": {
             "Name": "An Craite Greatsword",
-            "Info": "Every 2 turns, on turn start, if Damaged, Heal self and strengthen by 2.",
+            "Info": "Every 2 turns, on turn start, if Damaged, Heal self and Strengthen by 2.",
             "Flavor": "啊哈哈，你真让我笑掉大牙，北方佬！怎么？我手上这把大家伙，你都不一定拿得动，还想用它对付我？"
         },
         "64010": {
@@ -2653,7 +2653,7 @@
         },
         "64012": {
             "Name": "Tuirseach Skirmisher",
-            "Info": "Whenever this unit is resurrected, strengthen it by 4.",
+            "Info": "Whenever this unit is resurrected, Strengthen it by 4.",
             "Flavor": "记好了：我们对朋友掏心窝，对敌人挥斧子。"
         },
         "64013": {
@@ -2678,7 +2678,7 @@
         },
         "64017": {
             "Name": "Dimun Light Longship",
-            "Info": "On turn end, deal 1 Damage to the unit to the right, then boost self by 2.",
+            "Info": "On turn end, deal 1 Damage to the unit to the right, then Boost self by 2.",
             "Flavor": "你以为能在史凯利格海域逃出他们的手掌心？自求多福吧。"
         },
         "64018": {
@@ -2703,12 +2703,12 @@
         },
         "64022": {
             "Name": "Tuirseach Axeman",
-            "Info": "Whenever an enemy on the opposite row is Damaged, boost self by 1.\n2 Armor.",
+            "Info": "Whenever an enemy on the opposite row is Damaged, Boost self by 1.\n2 Armor.",
             "Flavor": "小姑娘才用剑，弄把斧头吧。"
         },
         "64023": {
             "Name": "An Craite Warcrier",
-            "Info": "Deploy: Boost an ally by half its power.",
+            "Info": "Deploy: Boost an ally by half its Power.",
             "Flavor": "有人为泰莫利亚抛头颅，有人为尼弗迦德洒热血。我只为骑士的誓言而战。"
         },
         "64024": {
@@ -2723,7 +2723,7 @@
         },
         "64026": {
             "Name": "Drummond Shieldmaid",
-            "Info": "Deploy: Deal 2 Damage to an enemy. If the target was already injured, play one copy from the deck.",
+            "Info": "Deploy: Deal 2 Damage to an enemy.\nIf the target was already injured, play one copy from the deck.",
             "Flavor": "我们的敌人会像打上嶙峋海岸的波浪一样，倒在我们的盾前。"
         },
         "64027": {
@@ -2763,7 +2763,7 @@
         },
         "64034": {
             "Name": "Bone Talisman",
-            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or Heal an ally and strengthen it by 3.",
+            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or Heal an ally and Strengthen it by 3.",
             "Flavor": "有时最普通不过的物件却拥有最为强大的威力。"
         },
         "65001": {
@@ -2818,22 +2818,22 @@
         },
         "61004": {
             "Name": "Bran Tuirseach",
-            "Info": "Deploy: Discard up to 3 cards from your deck and strengthen them by 1.",
+            "Info": "Deploy: Discard up to 3 cards from your deck and Strengthen them by 1.",
             "Flavor": "没人能取代布兰王，但后世定会努力尝试。"
         },
         "70001": {
             "Name": "Quen",
-            "Info": "Choose a Bronze or Silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any Damage once.",
+            "Info": "Choose a Bronze or Silver unit in your hand, Boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any Damage once.",
             "Flavor": ""
         },
         "70002": {
             "Name": "Detlaff: Higher Vampire",
-            "Info": "Deploy, Choose One: Play a Bronze unit from your deck with power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or Consume a bronze unit from your deck with more power than this unit and gain its power.",
+            "Info": "Deploy, Choose One: Play a Bronze unit from your deck with Power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or Consume a Bronze unit from your deck with more Power than this unit and gain its Power.",
             "Flavor": ""
         },
         "70003": {
             "Name": "Hammond",
-            "Info": "Deploy, Choose One: Spawn a Skellige Bronze Machine; or boost all friendly Machines on the board by 2.\nUnits in this row are Immune to Damage from Hazards.",
+            "Info": "Deploy, Choose One: Spawn a Skellige Bronze Machine; or Boost all friendly Machines on the board by 2.\nUnits in this row are Immune to Damage from Hazards.",
             "Flavor": ""
         },
         "70004": {
@@ -2843,32 +2843,32 @@
         },
         "70005": {
             "Name": "Vysogota Of Corvo",
-            "Info": "On round start, boost a unit to the left by 3, then Damage self by 1 and move to the row with the least amount of units.\nDeathwish: Boost the Lowest ally by 6.",
+            "Info": "On round start, Boost a unit to the left by 3, then Damage self by 1 and move to the row with the least amount of units.\nDeathwish: Boost the Lowest ally by 6.",
             "Flavor": ""
         },
         "70006": {
             "Name": "Lady Of The Lake",
-            "Info": "Deploy: Weaken self by the value equal to twice the number of the remaining cards in your hand and deck",
+            "Info": "Deploy: Weaken self by the value equal to twice the number of the remaining cards in your hand and deck.",
             "Flavor": ""
         },
         "70007": {
             "Name": "Prophet Lebioda",
-            "Info": "When Banished, boost all allies by 1.",
+            "Info": "When Banished, Boost all allies by 1.",
             "Flavor": ""
         },
         "70008": {
             "Name": "Vivienne: Oriole",
-            "Info": "On turn end, if your total power exceeds the opponent's power by 25 or more, return to your hand.",
+            "Info": "On turn end, if your total Power exceeds the opponent's Power by 25 points or more, return to your hand.",
             "Flavor": ""
         },
         "70009": {
             "Name": "Fleder",
-            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy becomes Damaged, boost self by 1.",
+            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy becomes Damaged, Boost self by 1.",
             "Flavor": ""
         },
         "70010": {
             "Name": "Protofleder",
-            "Info": "Deploy: Shuffle a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy becomes injured, boost self by 2.",
+            "Info": "Deploy: Shuffle a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy becomes injured, Boost self by 2.",
             "Flavor": ""
         },
         "70011": {
@@ -2878,7 +2878,7 @@
         },
         "70012": {
             "Name": "Toussaint Knight Errant",
-            "Info": "Deploy: For each card advantage your opponent has, boost self by 4 points.",
+            "Info": "Deploy: For each card advantage your opponent has, Boost self by 4.",
             "Flavor": ""
         },
         "70013": {
@@ -2888,7 +2888,7 @@
         },
         "70014": {
             "Name": "The Goddess of Justice",
-            "Info": "Bid for the Red Coin. Choose how many points you are willing to give up to start the game second. At the end of the first round, this card is Summoned to Blue Coin player's board from the graveyard.",
+            "Info": "Bid for the Red Coin.\nChoose how many points you are willing to give up to start the game second. At the end of the first round, this card is Summoned to Blue Coin player's board from the graveyard.",
             "Flavor": ""
         },
         "70015": {
@@ -2908,27 +2908,27 @@
         },
         "70019": {
             "Name": "Zoltan: Warrior",
-            "Info": "Deploy: Summon Figgis Merluzzo and Munro Bruys, then boost them by half the value of Zotan's boost.",
+            "Info": "Deploy: Summon Figgis Merluzzo and Munro Bruys, then Boost them by half the value of Zotan's Boost.",
             "Flavor": ""
         },
         "70020": {
             "Name": "Figgis Merluzzo",
-            "Info": "Deploy: Summon Zoltan Warrior and Munro Bruys, then boost them by half the value of Figgis' boost.",
+            "Info": "Deploy: Summon Zoltan Warrior and Munro Bruys, then Boost them by half the value of Figgis' Boost.",
             "Flavor": ""
         },
         "70021": {
             "Name": "Munro Bruys",
-            "Info": "Deploy: Summon Zoltan: Warrior and Figgis Merluzzo, then boost them by half the value of Munro's boost.",
+            "Info": "Deploy: Summon Zoltan: Warrior and Figgis Merluzzo, then Boost them by half the value of Munro's Boost.",
             "Flavor": ""
         },
         "70022": {
             "Name": "Kikimore Worker",
-            "Info": "Deploy: Choose an Insectoid ally, then boost all the cards with the same name on your side of the board, hand and deck by 2.",
+            "Info": "Deploy: Choose an Insectoid ally, then Boost all the cards with the same name on your side of the board, hand and deck by 2.",
             "Flavor": ""
         },
         "70023": {
             "Name": "Kikimore Warrior",
-            "Info": "Deploy: Consume a non-identical Bronze unit in your deck with current power no greater than its own, then boost self by its power.",
+            "Info": "Deploy: Consume a non-identical Bronze unit in your deck with current Power no greater than its own, then Boost self by its Power.",
             "Flavor": ""
         },
         "70024": {
@@ -2943,17 +2943,17 @@
         },
         "70026": {
             "Name": "Ivo of Belhaven",
-            "Info": "On round start, if you have more points than the opponent, strengthen self by 2.\nDeathwish: Move a random Bronze or Silver Witcher in your deck to the top of your deck.",
+            "Info": "On turn start, if you are winning, Strengthen self by 2.\nDeathwish: Move a random Bronze or Silver Witcher in your deck to the top of your deck.",
             "Flavor": ""
         },
         "70027": {
             "Name": "Geralt: Axii",
-            "Info": "Deploy: Replay a Bronze or Silver loyal unit from your opponent's side of the board and then move it back to the opponent's side of the board",
+            "Info": "Deploy: Replay a Bronze or Silver loyal unit from your opponent's side of the board, then move it back to the opposite row.",
             "Flavor": ""
         },
         "70032": {
             "Name": "Gascon",
-            "Info": "Deploy: Move all units to a random other row and Damage self by 2 for each unit moved.\nWhen in your hand or deck, boost self by 1 whenever a unit moves during your turn.",
+            "Info": "Deploy: Move all units to a random other row and Damage self by 2 for each unit moved.\nWhen in your hand or deck, Boost self by 1 whenever a unit moves during your turn.",
             "Flavor": "“Th' Strays of Spalla – 'tis you who lead them? 'Tis you they call the Duke of Dogs?”"
         },
         "70033": {
@@ -2963,7 +2963,7 @@
         },
         "70038": {
             "Name": "Sigvald",
-            "Info": "On turn end, resurrect to a random row and strengthen self by 1.",
+            "Info": "On turn end, resurrect to a random row and Strengthen self by 1.",
             "Flavor": "A vildkaarl that lives to old age earns the respect of his clan."
         },
         "70039": {
@@ -2978,12 +2978,12 @@
         },
         "70041": {
             "Name": "Giga Scorpion Decoction",
-            "Info": "Damage the strongest enemy by 2. Repeat 3 times. For each White Raffard's Decoction in your graveyard, repeat once more.",
+            "Info": "Damage the strongest enemy by 2\nRepeat 3 times.\nFor each White Raffard's Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70042": {
             "Name": "White Raffard's Decoction",
-            "Info": "Boost the weakest ally by 2. Repeat 3 times. For each Giga Scorpion Decoction in your graveyard, repeat once more.",
+            "Info": "Boost the weakest ally by 2.\nRepeat 3 times.\nFor each Giga Scorpion Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70043": {
@@ -3013,17 +3013,17 @@
         },
         "70054": {
             "Name": "Feign Death",
-            "Info": "Resurrect 2 Bronze units with power higher than 5, then deal 4 Damage to each of them.",
+            "Info": "Resurrect 2 Bronze units with Power higher than 5, then deal 4 Damage to each of them.",
             "Flavor": ""
         },
         "70058": {
             "Name": "Cave Troll",
-            "Info": "Deploy: Boost self by 4, then boost an enemy by 4.",
+            "Info": "Deploy: Boost self by 4, then Boost an enemy by 4.",
             "Flavor": ""
         },
         "70059": {
             "Name": "One-Eyed Betsy",
-            "Info": "At the beginning of the round, boost self by 3, then boost the Highest enemy by 3.",
+            "Info": "At the beginning of the round, Boost self by 3, then Boost the Highest enemy by 3.",
             "Flavor": "准头是差了点，但力道确实没话说。"
         },
         "70062": {
@@ -3048,12 +3048,12 @@
         },
         "70076": {
             "Name": "Congregation Cleric",
-            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base Strenght to 2. Whenever any Bronze unit is locked during your turn, generate a copy of it with 2 base strength in the same row as this unit.",
+            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base Strenght to 2.\nWhenever any Bronze unit is locked during your turn, generate a copy of it with 2 base Strength in the same row as this unit.",
             "Flavor": "“靠近点，羔羊，再近点。愿永恒之火温暖你的灵魂！”"
         },
         "70077": {
             "Name": "Firesworn Zealot",
-            "Info": "Every 4 turns, at the end of the turn, deal 2 Damage to 4 random enemies. Reduce the countdown by 1 for each locked unit on the board when played.",
+            "Info": "Every 4 turns, at the end of the turn, deal 2 Damage to 4 random enemies.\nReduce the countdown by 1 for each locked unit on the board when played.",
             "Flavor": "“我的信仰无人能敌，亦如我的怒火！”"
         },
         "70078": {
@@ -3078,12 +3078,12 @@
         },
         "70104": {
             "Name": "Lyrian Landsknecht",
-            "Info": "At the end of the round，if this card is boosted，shuffle it back to the deck and keep at most 10 boost.",
+            "Info": "At the end of the round，if this card is Boosted，shuffle it back to the deck and keep at most 10 Boost.",
             "Flavor": "“相信我，最好别去嘲笑他们傻里傻气的帽子。”"
         },
         "70105": {
             "Name": "Adalbertus Kalkstein",
-            "Info": "Deploy: Make a unit's strength equal to this card's strength.",
+            "Info": "Deploy: Make a unit's Strength equal to this card's Strength.",
             "Flavor": "“在卡尔克斯坦临刑之际，他用魔法火焰在天空拼出一句话。我们宅心仁厚的国王陛下对此可不太高兴……”"
         },
         "70106": {
@@ -3103,7 +3103,7 @@
         },
         "70109": {
             "Name": "Dwarven Chariot",
-            "Info": "Choose 2 units and move them to this unit's row. When this unit is moved, boost a random unit in the same row as this unit by 2.",
+            "Info": "Choose 2 units and move them to this unit's row.\nWhen this unit is moved, Boost a random unit in the same row as this unit by 2.",
             "Flavor": "“随你们怎么画，各位亲爱的矮人。但是我把话放在这里，它造不出来。”"
         },
         "130210": {
@@ -3113,7 +3113,7 @@
         },
         "130220": {
             "Name": "Prize-Winning Cow: Promoted",
-            "Info": "Deathwish: Spawn a Chort，and then deal 2 Damage to all emenies on the same row",
+            "Info": "Deathwish: Spawn a Chort, then deal 2 Damage to all emenies on the same row.",
             "Flavor": "哞～～～"
         },
         "130200": {
@@ -3123,7 +3123,7 @@
         },
         "130180": {
             "Name": "Vaedermakar: Promoted",
-            "Info": "Deploy: Spawn a Neutral Bronze or Silver Hazard, Clear Skies, or Alzur's Thunder",
+            "Info": "Deploy: Spawn a Neutral Bronze or Silver Hazard, Clear Skies, or Alzur's Thunder.",
             "Flavor": "控天者德鲁伊能操控各种元素之力，让狂风暴雨化为绕指柔风，降下毁天灭地的雹暴，还能拖雷掣电让敌军灰飞烟灭……所以我给你个忠告：面对他，一定要毕恭毕敬。"
         },
         "130190": {
@@ -3143,7 +3143,7 @@
         },
         "130020": {
             "Name": "Francis Bedlam: Promoted",
-            "Info": "Deploy: If losing, strengthen self up to a maximum of 20 until you outweight 1 scores",
+            "Info": "Deploy: If losing, Strengthen self up to a maximum of 20 until you have 1 more point than the opponent.",
             "Flavor": "要是我缺鼻子或者断手了，那显然，乞丐王接受这两种付款方式。"
         },
         "130160": {
@@ -3203,7 +3203,7 @@
         },
         "130070": {
             "Name": "Stregobor: Promoted",
-            "Info": "Deploy, Truce: Check two unit card in the opponent's deck, and place one on top of the deck.\nEach player draws a unit and sets its power to 1.",
+            "Info": "Deploy, Truce: Check two unit card in the opponent's deck, and place one on top of the deck.\nEach player draws a unit and sets its Power to 1.",
             "Flavor": "猎魔人见过看上去像议员的贼，见过看上去像乞丐的议员，也见过看上去像贼的国王。不过斯崔葛布的样子，就和大众心目中法师的形象没什么两样。"
         },
         "130030": {
@@ -3233,7 +3233,7 @@
         },
         "240250": {
             "Name": "Barbegazi: Promoted",
-            "Info": "Consume an ally and boost self by its power.\nResilient.",
+            "Info": "Consume an ally and Boost self by its Power.\nResilient.",
             "Flavor": "岩洞中先前还和石头没什么两样的怪物，倏地瞪大眼睛，充满恶意地盯着他。"
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -268,7 +268,7 @@
         },
         "12009": {
             "Name": "Ale of the Ancestors",
-            "Info": "Deploy: Apply Golden Froth to the row. Repeat this ability when moved, then deal 4 Damage to self.",
+            "Info": "Deploy: Apply Golden Froth to the row.\nRepeat its ability when moved, then deal 4 Damage to self.",
             "Flavor": "Boros, the legendary founder of Clan Fuchs, died after overindulging in this beverage - he passed out while reaching for his golden ring, which had fallen into a brook."
         },
         "12010": {
@@ -903,7 +903,7 @@
         },
         "22001": {
             "Name": "Old Speartip: Asleep",
-            "Info": "Deploy: Strengthen all your other Ogroids in hand, deck, and on board by 1.",
+            "Info": "Deploy: Strengthen all your other Ogroids in hand, deck and on board by 1.",
             "Flavor": "别吵！"
         },
         "22002": {
@@ -1368,7 +1368,7 @@
         },
         "32008": {
             "Name": "Menno Coehoorn",
-            "Info": "Deploy: Damage an enemy by 4.\nIf it is Spying, destroy it.",
+            "Info": "Deploy: Damage an enemy by 4.\nIf it's Spying, destroy it.",
             "Flavor": "细心的侦察分队比训练有素的军团更管用。"
         },
         "32009": {
@@ -1413,7 +1413,7 @@
         },
         "33004": {
             "Name": "Cantarella",
-            "Info": "Spying. Single-Use.\nDeploy: Draw 2 cards.\nKeep one and move the other to the bottom of your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Look at the top 2 cards from your deck.\nDraw one and move the other to the bottom of your deck.",
             "Flavor": "男人渴望着诱惑，神秘加优雅往往事半功倍。"
         },
         "33005": {
@@ -1558,7 +1558,7 @@
         },
         "34011": {
             "Name": "Rot Tosser",
-            "Info": "Deploy: Spawn a Cow Carcass on an enemy row.\n(After 2 turns, on turn end, destroy all the other Lowest units on the row and destroy self).",
+            "Info": "Deploy: Spawn a Cow Carcass on an enemy row.\n(After 2 turns, on turn end, destroy all the other Lowest units on the row and destroy self)",
             "Flavor": "向围城中散播瘟疫是否人道，这个话题还是留给史学家吧。我们只关心这法子有没有效。"
         },
         "34012": {
@@ -1578,12 +1578,12 @@
         },
         "34015": {
             "Name": "Deithwen Arbalest",
-            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf it is Spying, deal 8 Damage instead.",
+            "Info": "Deploy: Deal 4 Damage to an enemy.\nIf it's Spying, deal 8 Damage instead.",
             "Flavor": "我只瞄膝盖，一向如此。"
         },
         "34016": {
             "Name": "Mangonel",
-            "Info": "Deploy: Deal 2 Damage to a random enemy.\nRepeat this ability whenever you Reveal a card.",
+            "Info": "Deploy: Deal 2 Damage to a random enemy.\nRepeat its ability whenever you Reveal a card.",
             "Flavor": "适用于投掷残骸和干粪。"
         },
         "34017": {
@@ -1663,7 +1663,7 @@
         },
         "34001": {
             "Name": "Vicovaro Novice",
-            "Info": "Deploy: Look at 2 random Bronze Alchemy cards from your deck.\nPlay 1 and shuffle the other back.",
+            "Info": "Deploy: Look at 2 random Bronze Alchemy cards from your deck, then play 1.",
             "Flavor": "尼弗迦德的法师们就像手纸。一旦谁被皇帝厌倦，立刻有大把新人迫不及待地赶来补缺。"
         },
         "34029": {
@@ -1788,7 +1788,7 @@
         },
         "43001": {
             "Name": "Thaler",
-            "Info": "Spying. Single-Use.\nDeploy: Draw 2 cards.\nKeep one and shuffle the other to your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Look at 2 random cards from your deck.\nDraw one and shuffle the other to your deck.",
             "Flavor": "滚开！我们中间不是每个人都那么轻浮、那么浅薄……"
         },
         "43002": {
@@ -2103,7 +2103,7 @@
         },
         "52002": {
             "Name": "Saesenthessis",
-            "Info": "Deploy: Boost self by 1 for each Dwarf ally on the board and in your hand and deal 1 Damage to an enemy for each Elf ally on the board and in your hand.",
+            "Info": "Deploy: Boost self by 1 for each Dwarf ally on the board and in your hand and deal 1 Damage for each Elf ally on the board and in your hand.",
             "Flavor": "我继承了父亲的变身能力……好吧，尽管我只有一种变化形态。"
         },
         "52003": {
@@ -2163,7 +2163,7 @@
         },
         "53001": {
             "Name": "Yaevinn",
-            "Info": "Spying. Single-Use.\nDeploy: Draw a special card and a unit.\nKeep one and shuffle the other to your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Look at a random special card and a random unit from your deck.\nDraw one and shuffle the other to your deck.",
             "Flavor": "我们是汇成风暴的雨滴。"
         },
         "53002": {
@@ -2183,7 +2183,7 @@
         },
         "53005": {
             "Name": "Dennis Cranmer",
-            "Info": "Deploy: Strengthen all your other Dwarves in hand, deck, and on board by 1.",
+            "Info": "Deploy: Strengthen all your other Dwarves in hand, deck and on board by 1.",
             "Flavor": "我知道如何执行命令，冲别人去说教吧。"
         },
         "53006": {
@@ -2208,7 +2208,7 @@
         },
         "53010": {
             "Name": "Braenn",
-            "Info": "Deploy: Deal Damage equal to this unit's Power to an enemy.\nIf a unit was destroyed, Boost all your other Dryads and Ambush units in hand, deck, and on board by 1.",
+            "Info": "Deploy: Damage an enemy by this unit's power.\nIf the unit was destroyed, Boost all your other Dryads and Ambush units in hand, deck and on board by 1.",
             "Flavor": "莫娜？不，不。我是布蕾恩。布洛克莱昂的女儿。"
         },
         "53011": {
@@ -2228,7 +2228,7 @@
         },
         "53014": {
             "Name": "Milaen",
-            "Info": "Deploy: Deal 6 Damage to the units at the end of a row.",
+            "Info": "Deploy: Deal 6 Damage to the units at the end of an enemy row.",
             "Flavor": "老男爵对待偷猎者向来毫不留情。幸亏麦莉运气够好，老男爵已经死了，他的手下也成了亡命之徒。"
         },
         "53015": {
@@ -2333,7 +2333,7 @@
         },
         "54014": {
             "Name": "Dol Blathanna Bomber",
-            "Info": "Deploy: Spawn an Incinerating Trap on an enemy row.",
+            "Info": "Deploy: Spawn an Incinerating Trap on an enemy row.\n(Damage all units on this row by 2 on turn end)",
             "Flavor": "他们的追踪本领犹如猎犬，双腿健似矫鹿，残忍更胜恶魔。"
         },
         "54015": {
@@ -2368,7 +2368,7 @@
         },
         "54021": {
             "Name": "Elven Swordmaster",
-            "Info": "Deploy: Deal Damage equal to this unit's Power.",
+            "Info": "Deploy: Damage an enemy by this unit's Power.",
             "Flavor": "战斗如同舞蹈，千万不能让你的对手领舞。"
         },
         "54022": {
@@ -2428,7 +2428,7 @@
         },
         "55001": {
             "Name": "Incinerating Trap",
-            "Info": "Damage all units on this row by 2 on turn end",
+            "Info": "Spying.\nDamage all units on this row by 2 on turn end",
             "Flavor": "小心……！再走一步，你就要被化成青烟了。"
         },
         "62001": {
@@ -2438,7 +2438,7 @@
         },
         "62002": {
             "Name": "Hjalmar an Craite",
-            "Info": "Deploy: Spawn the Lord of Undvik on the opposite row.",
+            "Info": "Deploy: Spawn the Lord of Undvik on the opposite row.\n(Deathwish: Boost enemy Hjalmars by 10)",
             "Flavor": "別为死者哭泣，敬他们一杯吧！"
         },
         "62003": {
@@ -2493,7 +2493,7 @@
         },
         "62013": {
             "Name": "Kambi",
-            "Info": "Spying.\nDeathwish: Spawn Hemdall.",
+            "Info": "Spying.\nDeathwish: Spawn Hemdall.\n(Deploy: Destroy all units and clear all Boons and Hazards.",
             "Flavor": "终焉之刻来临时，金公鸡坎比便会叫醒沉睡的汉姆多尔。"
         },
         "63001": {
@@ -2503,7 +2503,7 @@
         },
         "63002": {
             "Name": "Udalryk",
-            "Info": "Spying. Single-Use.\nDeploy: Look at 2 cards from your deck.\nDraw one and Discard the other.",
+            "Info": "Spying. Single-Use.\nDeploy: Look at 2 random cards from your deck.\nDraw one and Discard the other.",
             "Flavor": "诸神已经发话，必须献上祭品。"
         },
         "63003": {
@@ -2513,12 +2513,12 @@
         },
         "63004": {
             "Name": "Blueboy Lugos",
-            "Info": "Deploy: Spawn a Spectral Whale on an enemy row.",
+            "Info": "Deploy: Spawn a Spectral Whale on an enemy row.\n(On turn end, move to a random row and deal 1 Damage to all units on it)",
             "Flavor": "我无聊得快吐了。"
         },
         "63005": {
             "Name": "Morkvarg",
-            "Info": "Whenever this unit enter the graveyard, resurrect it and Weaken it by half.",
+            "Info": "Whenever this unit enters the graveyard, resurrect it and Weaken it by half.",
             "Flavor": "史凯利格有史以来最大的恶人。"
         },
         "63006": {
@@ -2588,7 +2588,7 @@
         },
         "63019": {
             "Name": "Restore",
-            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base Power to 8.\nThen play a card.",
+            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base Power to 8, then play a card.",
             "Flavor": "那些该死的女术士又抢咱们的风头！只要几个年轻姑娘挥挥手就能解决的话，谁还选择这么费时费力的办法？"
         },
         "63020": {
@@ -2608,7 +2608,7 @@
         },
         "64003": {
             "Name": "Heymaey Flaminica",
-            "Info": "Deploy: Clear Hazards from the row and move 2 allies to it.",
+            "Info": "Deploy: Clear Hazards from its row and move 2 allies to it.",
             "Flavor": "佛兰明妮卡是女德鲁伊最高领袖的头衔，她备受众人的崇敬，拥有无比的力量。"
         },
         "64004": {
@@ -2633,7 +2633,7 @@
         },
         "64008": {
             "Name": "Savage Bear",
-            "Info": "Whenever a unit is played from either hand on your opponent's side, deal 1 Damage to it.",
+            "Info": "Whenever a unit is played from either hand on your opponent's side of the board, deal 1 Damage to it.",
             "Flavor": "“驯服”？哈，小子，史凯利格人也许能训练它们，但那跟驯服完全不同……"
         },
         "64009": {
@@ -2668,12 +2668,12 @@
         },
         "64015": {
             "Name": "An Craite Armorsmith",
-            "Info": "Deploy: Heal 2 allies and and give them 3 Armor.",
+            "Info": "Deploy: Heal 2 allies and give them 3 Armor.",
             "Flavor": "你是讨打。"
         },
         "64016": {
             "Name": "Tuirseach Veteran",
-            "Info": "Deploy: Strengthen all your other Clan Tuirseach units in hand, deck, and on board by 1.",
+            "Info": "Deploy: Strengthen all your other Clan Tuirseach units in hand, deck and on board by 1.",
             "Flavor": "我见人所未见，能人所不能。"
         },
         "64017": {
@@ -2683,7 +2683,7 @@
         },
         "64018": {
             "Name": "An Craite Longship",
-            "Info": "Deploy: Deal 2 Damage to a random enemy.\nRepeat this ability whenever you Discard a card.",
+            "Info": "Deploy: Deal 2 Damage to a random enemy.\nRepeat its ability whenever you Discard a card.",
             "Flavor": "据说只要有长船出海劫掠，汉姆多尔就会心潮澎湃。"
         },
         "64019": {
@@ -2723,7 +2723,7 @@
         },
         "64026": {
             "Name": "Drummond Shieldmaid",
-            "Info": "Deploy: Deal 2 Damage to an enemy.\nIf the target was already injured, play one copy from the deck.",
+            "Info": "Deploy: Deal 2 Damage.\nIf the target was already injured, play a copy of this unit from your deck.",
             "Flavor": "我们的敌人会像打上嶙峋海岸的波浪一样，倒在我们的盾前。"
         },
         "64027": {
@@ -2763,7 +2763,7 @@
         },
         "64034": {
             "Name": "Bone Talisman",
-            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or Heal an ally and Strengthen it by 3.",
+            "Info": "Choose One: Resurrect a Bronze Beast or Cultist; or Heal an ally and Strengthen it by 3.",
             "Flavor": "有时最普通不过的物件却拥有最为强大的威力。"
         },
         "65001": {
@@ -2833,7 +2833,7 @@
         },
         "70003": {
             "Name": "Hammond",
-            "Info": "Deploy, Choose One: Spawn a Skellige Bronze Machine; or Boost all friendly Machines on the board by 2.\nUnits in this row are Immune to Damage from Hazards.",
+            "Info": "Deploy, Choose One: Spawn a Skellige Bronze Machine; or Boost all allied Machines on the board by 2.\nUnits in this row are Immune to Damage from Hazards.",
             "Flavor": ""
         },
         "70004": {
@@ -2863,12 +2863,12 @@
         },
         "70009": {
             "Name": "Fleder",
-            "Info": "Deploy: Summon a card with the same name from your deck to the same row.\nWhenever a Bronze or Silver enemy becomes Damaged, Boost self by 1.",
+            "Info": "Deploy: Summon a copy of this unit from your deck to the same row.\nWhenever a Bronze or Silver enemy becomes Damaged, Boost self by 1.",
             "Flavor": ""
         },
         "70010": {
             "Name": "Protofleder",
-            "Info": "Deploy: Shuffle a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy becomes injured, Boost self by 2.",
+            "Info": "Deploy: Add a Fleder to the top of your deck.\nWhenever a Bronze or Silver enemy becomes injured, Boost self by 2.",
             "Flavor": ""
         },
         "70011": {
@@ -2893,12 +2893,12 @@
         },
         "70015": {
             "Name": "Brokilon Sentinel",
-            "Info": "On round end, if the opponent has exactly 4 units in the opposing row, deal 1 Damage to all enemies in that row.",
+            "Info": "On turn end, if the opponent has exactly 4 units in the opposing row, deal 1 Damage to all enemies in that row.",
             "Flavor": ""
         },
         "70016": {
             "Name": "Sukrus",
-            "Info": "Deploy: Choose 1 Bronze card in your hand and Discard all cards with the same name from the deck.",
+            "Info": "Deploy: Choose 1 Bronze card in your hand and Discard all copies of it from your deck.",
             "Flavor": ""
         },
         "70017": {
@@ -2923,7 +2923,7 @@
         },
         "70022": {
             "Name": "Kikimore Worker",
-            "Info": "Deploy: Choose an Insectoid ally, then Boost all the cards with the same name on your side of the board, hand and deck by 2.",
+            "Info": "Deploy: Choose an Insectoid ally.\nBoost that unit and all copies of it on your side of the board, hand and deck by 2.",
             "Flavor": ""
         },
         "70023": {
@@ -3133,7 +3133,7 @@
         },
         "130010": {
             "Name": "Roach: Promoted",
-            "Info": "Whenever you play a Gold unit from your hand, Summon this unit.\nIf it is in your hand, Summon it and draw one card.\nIf it is in your graveyard, return to your deck.",
+            "Info": "Whenever you play a Gold unit from your hand, Summon this unit.\nIf it's in your hand, Summon it and draw one card.\nIf it's in your graveyard, return to your deck.",
             "Flavor": "杰洛特，我们得来场人马间的对话。恕我直言，你的骑术……真的有待提高，伙计。"
         },
         "130150": {
@@ -3203,7 +3203,7 @@
         },
         "130070": {
             "Name": "Stregobor: Promoted",
-            "Info": "Deploy, Truce: Check two unit card in the opponent's deck, and place one on top of the deck.\nEach player draws a unit and sets its Power to 1.",
+            "Info": "Deploy, Truce: Look at two units in the opponent's deck, then place one on top of the deck.\nEach player draws a unit and sets its Power to 1.",
             "Flavor": "猎魔人见过看上去像议员的贼，见过看上去像乞丐的议员，也见过看上去像贼的国王。不过斯崔葛布的样子，就和大众心目中法师的形象没什么两样。"
         },
         "130030": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -248,7 +248,7 @@
         },
         "12005": {
             "Name": "Ciri: Dash",
-            "Info": "Whenever this unit enters the graveyard, return it to your deck and Strengthen it by 3.",
+            "Info": "Whenever this unit enters the graveyard, return it to your deck and strengthen it by 3.",
             "Flavor": "Know when fairy tales cease to be tales? When people start believing them."
         },
         "12006": {
@@ -278,7 +278,7 @@
         },
         "12011": {
             "Name": "Dandelion: Vainglory",
-            "Info": "Deploy: For every Geralt, Yennefer, Triss and Zoltan card in your starting deck, boost self by 3.",
+            "Info": "Deploy: For every Geralt, Yennefer, Triss and Zoltan Gold card in your starting deck, boost self by 3.",
             "Flavor": "Dandelion told me all about your adventures. How'd he ready you for battle with his songs, how he tamed the kayran by playin' his lute..."
         },
         "12012": {
@@ -308,7 +308,7 @@
         },
         "12017": {
             "Name": "Geralt: Professional",
-            "Info": "Deploy: Deal 4 damage to an enemy unit. If it's a Monster unit, destroy it instead.",
+            "Info": "Deploy: Deal 4 damage to an enemy unit.\nIf it's a Monster unit, destroy it instead.",
             "Flavor": "I accepted a job once, did it. Asked to choose my reward, I invoked the Law of Surprise."
         },
         "12018": {
@@ -318,7 +318,7 @@
         },
         "12019": {
             "Name": "Ciri",
-            "Info": "Whenever you lose a round, return this unit to your hand. 2 armor.",
+            "Info": "Whenever you lose a round, return this unit to your hand. 2 Armor.",
             "Flavor": "I go wherever I please, whenever I please"
         },
         "12020": {
@@ -333,7 +333,7 @@
         },
         "12022": {
             "Name": "Regis: Higher Vampire",
-            "Info": "Deploy: Look at 3 Bronze units from your opponent's deck. Consume 1, then boost self by its base power.",
+            "Info": "Deploy: Look at 3 Bronze units from your opponent's deck.\nConsume 1, then boost self by its base power.",
             "Flavor": "He becomes invisible at will. His glance hypnotizes into a deep sleep. He then drinks his fill, turns into a bat and flies off. Altogether uncouth."
         },
         "12023": {
@@ -353,12 +353,12 @@
         },
         "12026": {
             "Name": "Triss: Telekinesis",
-            "Info": "Deploy: Create and play a Bronze special card from either player's starting deck.",
+            "Info": "Deploy: Create and play a Bronze Special card from either player's starting deck.",
             "Flavor": "Bindings won't suffice. Nor will a gag render her any less dangerous. No, dimeritium is the only solution."
         },
         "12002": {
             "Name": "Geralt: Igni",
-            "Info": "Deploy: Destroy the Highest units on an enemy row if that row has a total of 25 or more.",
+            "Info": "Deploy: Destroy the Highest units on an enemy row if that row has a total of 25 points or more.",
             "Flavor": "A twist of a witcher's fingers can light a lamp… or incinerate a foe."
         },
         "12027": {
@@ -373,7 +373,7 @@
         },
         "12003": {
             "Name": "Dandelion: Poet",
-            "Info": "Deploy: Draw 1 card and then play 1 card.",
+            "Info": "Deploy: Draw 1 card, then play 1 card.",
             "Flavor": "The quill is mightier than the sword."
         },
         "12029": {
@@ -438,7 +438,7 @@
         },
         "12040": {
             "Name": "Trial of the Grasses",
-            "Info": "Deal 10 damage to a unit, unless it's a Witcher. If it survives, boost it to 25 power.",
+            "Info": "Deal 10 damage to a unit, unless it's a Witcher.\nIf it survives, boost it to 25 power.",
             "Flavor": "Imagine a lump of clay. In order to shape it, you must first moisten it or it will crumble. The Trial's initial part does just that. It opens the body to change, so to speak. Only then can the mutagens produce a witcher."
         },
         "12041": {
@@ -458,7 +458,7 @@
         },
         "13004": {
             "Name": "Iris' Companions",
-            "Info": "Deploy: Move a card from your deck to your hand, then Discard a random card.",
+            "Info": "Deploy: Move a card from your deck to your hand, then discard a random card.",
             "Flavor": "我们的名字还是不说为好。就当我们是……主人家的朋友吧。"
         },
         "13005": {
@@ -473,12 +473,12 @@
         },
         "13007": {
             "Name": "Stregobor",
-            "Info": "Single-Use. Deploy, Truce: Each player draws a unit and sets its power to 1.",
+            "Info": "Single-Use.\nDeploy, Truce: Each player draws a unit and sets its power to 1.",
             "Flavor": "猎魔人见过看上去像议员的贼，见过看上去像乞丐的议员，也见过看上去像贼的国王。不过斯崔葛布的样子，就和大众心目中法师的形象没什么两样。"
         },
         "13008": {
             "Name": "Johnny",
-            "Info": "Deploy: Discard a card. Then make a copy of a card of the same color from your opponent's starting deck in your hand.",
+            "Info": "Deploy: Discard a card, then make a copy of a card of the same color from your opponent's starting deck in your hand.",
             "Flavor": "要是再也没办法亲口说出“狮子头上长虱子”，生活就真的太无趣啦。"
         },
         "13009": {
@@ -488,7 +488,7 @@
         },
         "13010": {
             "Name": "Ocvist",
-            "Info": "Single-Use: After 4 turns, on turn start, deal 1 damage to all enemies, then return to your hand.",
+            "Info": "Single-Use.\nAfter 4 turns, on turn start, deal 1 damage to all enemies, then return to your hand.",
             "Flavor": "他是石英山之主，毁灭者，图拉真的屠夫。但在闲暇时间里，他喜欢远足和烛光晚餐。"
         },
         "13011": {
@@ -543,7 +543,7 @@
         },
         "13019": {
             "Name": "Iris von Everec",
-            "Info": "Spying. Deathwish: Boost 5 random units on the opposite side by 5.",
+            "Info": "Spying.\nDeathwish: Boost 5 random units on the opposite side by 5.",
             "Flavor": "我的回忆所剩无几……但每次想到我的玫瑰，记忆便会涌现。"
         },
         "13020": {
@@ -618,7 +618,7 @@
         },
         "13034": {
             "Name": "Scorch",
-            "Info": "Destroy all the Highest Units.",
+            "Info": "Destroy all the Highest units.",
             "Flavor": "杰洛特退了一步。他见过不少被烧弹击中的人，更准确地说，他见过不少烧弹留下的残骸。"
         },
         "13035": {
@@ -633,7 +633,7 @@
         },
         "13037": {
             "Name": "The Last Wish",
-            "Info": "Draw your top 2 cards. Play 1 and shuffle the other back.",
+            "Info": "Draw your top 2 cards.\nPlay 1 and shuffle the other back.",
             "Flavor": "亲爱的先生们，一只气灵三个愿望，随后它们就会跑回自己的界域去。"
         },
         "13038": {
@@ -648,7 +648,7 @@
         },
         "13040": {
             "Name": "Mandrake",
-            "Info": "Choose One: Heal a unit and Strengthen it by 6; or Reset a unit and Weaken it by 6.",
+            "Info": "Choose One: Heal a unit and strengthen it by 6; or reset a unit and weaken it by 6.",
             "Flavor": "衮衮诸公，瞠目环立，不肯相信这高贵的发现。有的在谈曼陀罗花，有的又说是在用黑犬。"
         },
         "13041": {
@@ -663,7 +663,7 @@
         },
         "13043": {
             "Name": "Dragon's Dream",
-            "Info": "Apply a Hazard to an enemy row that will explode and deal 4 damage to all units when a different special card is played.",
+            "Info": "Apply a Hazard to an enemy row that will explode and deal 4 damage to all units when a different Special card is played.",
             "Flavor": "在瑟瑞卡尼亚，龙神崇拜体现在日常生活的各个方面。因此也难怪他们会以此为武器命名了。"
         },
         "13044": {
@@ -678,7 +678,7 @@
         },
         "14003": {
             "Name": "Alzur's Thunder",
-            "Info": "Deal 9 damage.",
+            "Info": "Deal 9 damage to a unit.",
             "Flavor": "我们全然无法念诵“阿尔祖落雷术”这样深奥复杂的咒语。据说，阿尔祖声如狩猎号角，言若讲演名家。"
         },
         "14004": {
@@ -693,12 +693,12 @@
         },
         "14006": {
             "Name": "Bloodcurdling Roar",
-            "Info": "Destroy an ally. Spawn and play a Bear.",
+            "Info": "Destroy an ally, then Spawn an Elder Bear",
             "Flavor": "起初我们碰上了一头熊……悲剧就从那时开始了。"
         },
         "14007": {
             "Name": "Dimeritium Shackles",
-            "Info": "Toggle a unit's Lock status. If an enemy, deal 5 damage to it.",
+            "Info": "Toggle a unit's Lock status.\nIf an enemy, deal 5 damage to it.",
             "Flavor": "The mage's arms were twisted and bound behind his back. The Redanians gave the fetters a good shake. Terranova cried out, lurched, bent backwards, bowed forward, then retched and groaned. It was clear of what his manacles were made."
         },
         "14008": {
@@ -728,7 +728,7 @@
         },
         "14013": {
             "Name": "Mardroeme",
-            "Info": "Choose One: Reset a unit and Strengthen it by 3; or Reset a unit and Weaken it by 3.",
+            "Info": "Choose One: Reset a unit and strengthen it by 3; or reset a unit and weaken it by 3.",
             "Flavor": "Carried by the wind across the Continent… Sowing madness and blight where they fall."
         },
         "14014": {
@@ -778,7 +778,7 @@
         },
         "14023": {
             "Name": "Rock Barrage",
-            "Info": "Deal 7 damage to an enemy and move it to the row above. If the row is full, destroy the enemy instead.",
+            "Info": "Deal 7 damage to an enemy and move it to the row above.\nIf the row is full, destroy the enemy instead.",
             "Flavor": "有一天等你老了，也会难逃被石头砸中的厄运。"
         },
         "14024": {
@@ -878,7 +878,7 @@
         },
         "21001": {
             "Name": "Dagon",
-            "Info": "Deploy: Spawn Fog or Rain.",
+            "Info": "Deploy: Spawn Impenetrable Fog or Torrential Rain.",
             "Flavor": "永世长眠者未必永恒死亡，在奇妙的时代死亡亦将消逝。"
         },
         "21002": {
@@ -923,7 +923,7 @@
         },
         "22005": {
             "Name": "Imlerith",
-            "Info": "Deploy: Damage an Enemy by 4. If the Enemy is under a Frost Hazard, Destory it instead. ",
+            "Info": "Deploy: Damage an Enemy by 4.\nIf the Enemy is under a Frost Hazard, Destory it instead. ",
             "Flavor": "叫他们有来无回！"
         },
         "22006": {
@@ -938,12 +938,12 @@
         },
         "22008": {
             "Name": "Woodland Spirit",
-            "Info": "Deploy: Spawn 3 Wolves and apply a Fog to the opposite row.",
+            "Info": "Deploy: Spawn 3 Wolves and apply Impenetrable Fog to the opposite row.",
             "Flavor": "即便全村人都饿肚子，我们也绝不去这片树林打猎。"
         },
         "22009": {
             "Name": "Imlerith: Sabbath",
-            "Info": "Every turn, on turn end, Duel the Highest enemy. If this unit survives, Heal it by 2 and give it 2 Armor. 2 Armor. Repeat up to 2 times.",
+            "Info": "Every turn, on turn end, duel the Highest enemy.\nIf this unit survives, heal it by 2 and give it 2 Armor.\nRepeat up to 2 times.\n2 Armor.",
             "Flavor": "老巫妪说过你会来。她们在水面上预见了你的到来。"
         },
         "22010": {
@@ -963,7 +963,7 @@
         },
         "22013": {
             "Name": "Ge'els",
-            "Info": "Deploy: Draw the top Gold card and top Silver card from your Deck. Play one and return the other to the top of your Deck. ",
+            "Info": "Deploy: Draw the top Gold card and top Silver card from your Deck.\nPlay one and return the other to the top of your Deck. ",
             "Flavor": "画作传情，而非言词。"
         },
         "22014": {
@@ -973,7 +973,7 @@
         },
         "23001": {
             "Name": "Frightener",
-            "Info": "Spying. Single-Use. Deploy: Move an enemy to this unit's row and draw a card.",
+            "Info": "Spying. Single-Use.\nDeploy: Move an enemy to this unit's row and draw a card.",
             "Flavor": "“我到底做了什么？”法师被自己的创造物吓得大叫起来。"
         },
         "23002": {
@@ -1013,22 +1013,22 @@
         },
         "23009": {
             "Name": "Jotunn",
-            "Info": "Deploy: Move 3 Enemies to this row on their side and Damage them by 2. If that row is affected by Frost Hazard, Damage them by 3 instead.",
+            "Info": "Deploy: Move 3 enemies to this row on their side and damage them by 2.\nIf that row is affected by Biting Frost, damage them by 3 instead.",
             "Flavor": "在史凯利格的传说中，强大而恐怖的巨人之王约顿是群岛在上古时期的统治者。他最终死于汉姆多尔的剑下，但在弥留之际，他发誓要在终末之战时重返人间。"
         },
         "23010": {
             "Name": "Morvudd",
-            "Info": "Deploy: Toggle a unit's Lock status. If it was an enemy, halve its power.",
+            "Info": "Deploy: Toggle a unit's Lock status.\nIf it was an enemy, halve its power.",
             "Flavor": "一种只在大史凯利格出没的珍稀鹿首魔品种。对食物异乎寻常的挑剔。"
         },
         "23011": {
             "Name": "Nithral",
-            "Info": "Deploy: Deal 6 damage to an enemy. Increase damage by 1 for each Wild Hunt unit in your hand.",
+            "Info": "Deploy: Deal 6 damage to an enemy.\nIncrease damage by 1 for each Wild Hunt unit in your hand.",
             "Flavor": "每个狂猎战士都要经过严格筛选，而只有最残暴、最凶狠的那些才能加入艾瑞汀的骑兵队。"
         },
         "23012": {
             "Name": "Toad Prince",
-            "Info": "Deploy: Draw a unit, then Consume a unit in your hand and boost self by its power.",
+            "Info": "Deploy: Draw a unit, then consume a unit in your hand and boost self by its power.",
             "Flavor": "又大又坏又丑，住在下水道里。"
         },
         "23013": {
@@ -1048,7 +1048,7 @@
         },
         "23016": {
             "Name": "Abaya",
-            "Info": "Deploy: Spawn Rain, Clear Skies or Arachas Venom.",
+            "Info": "Deploy: Spawn Torrential Rain, Clear Skies or Arachas Venom.",
             "Flavor": "丑东西我见得多了，海鳝、七鳃鳗、水滴鱼……但还没见过这么丑的！"
         },
         "23017": {
@@ -1063,12 +1063,12 @@
         },
         "23019": {
             "Name": "She-Troll of Vergen",
-            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, Consume it and boost self by its base power",
+            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, consume it and boost self by its base power",
             "Flavor": "着迷于精灵洋葱汤。"
         },
         "23020": {
             "Name": "Devana Runestone",
-            "Info": "Deploy: Create a Bronze or Silver Monster card.",
+            "Info": "Create a Bronze or Silver Monster card.",
             "Flavor": "我的剑实在是锋利，连纸都能裁开！"
         },
         "23021": {
@@ -1078,7 +1078,7 @@
         },
         "23022": {
             "Name": "Parasite",
-            "Info": "Choose One: Deal 12 damage to an enemy; or Boost an ally by 12.",
+            "Info": "Choose One: Deal 12 damage to an enemy; or boost an ally by 12.",
             "Flavor": "确实引人注目。"
         },
         "24001": {
@@ -1093,17 +1093,17 @@
         },
         "24003": {
             "Name": "Ancient Foglet",
-            "Info": "On turn end, if Fog is on the board, Boost self by 1.",
+            "Info": "On turn end, if Impenetrable Fog is on the board, Boost self by 1.",
             "Flavor": "人类心中潜藏着许多原始的恐惧。对迷雾的恐惧更是根深蒂固……"
         },
         "24004": {
             "Name": "Archgriffin",
-            "Info": "Deploy: Clear Hazards on its row. Move a Bronze unit from the opponent's graveyard to your own graveyard.",
+            "Info": "Deploy: Clear Hazards on its row.\nMove a Bronze unit from the opponent's graveyard to your own graveyard.",
             "Flavor": "大狮鹫也是狮鹫，只是更加凶悍。"
         },
         "24005": {
             "Name": "Wild Hunt Rider",
-            "Info": "Increase the damage dealt by Frost on the opposite row by 1.",
+            "Info": "Increase the damage dealt by Biting Frost on the opposite row by 1.",
             "Flavor": "首先映入眼帘的是头盔旁的两只水牛角，接着是牛角间的头冠，最后是面甲下白骨般的脸。"
         },
         "24006": {
@@ -1128,7 +1128,7 @@
         },
         "24010": {
             "Name": "Arachas Behemoth",
-            "Info": "Whenever you Consume a unit, Spawn an Arachas Hatchling. Repeat up to 3 times.",
+            "Info": "Whenever you consume a unit, Spawn an Arachas Hatchling.\nRepeat up to 3 times.",
             "Flavor": "看起来像螃蟹和蜘蛛的杂交……只是体型硕大无比。"
         },
         "24011": {
@@ -1148,7 +1148,7 @@
         },
         "24014": {
             "Name": "Drowner",
-            "Info": "Deploy: Move an enemy to the opposite row and deal 2 damage to it. If that row is under a Hazard, deal 4 damage instead.",
+            "Info": "Deploy: Move an enemy to the opposite row and deal 2 damage to it.\nIf that row is under a Hazard, deal 4 damage instead.",
             "Flavor": "尽管猎魔人想多赚些金币，但杀水鬼这活儿只值一枚银币，或者三个铜板——不能再多了。"
         },
         "24015": {
@@ -1158,7 +1158,7 @@
         },
         "24016": {
             "Name": "Wild Hunt Warrior",
-            "Info": "Deploy: Deal 4 damage to an enemy. If the enemy is destroyed or is under Frost, boost self by 2.",
+            "Info": "Deploy: Deal 4 damage to an enemy.\nIf the enemy is destroyed or is under Biting Frost, boost self by 2.",
             "Flavor": "白霜将至。"
         },
         "24017": {
@@ -1183,27 +1183,27 @@
         },
         "24021": {
             "Name": "Ice Giant",
-            "Info": "Deploy: For every Biting Frost on the Board, gain 3 points. Every time a Biting Frost appears on the Board, gain 3 points.",
+            "Info": "Deploy: For every Biting Frost on the board, boost self by 3 points. Every time a Biting Frost appears on the board, boost self by 3 points.",
             "Flavor": "我这辈子只当过一次逃兵，就是碰上寒冰巨人那次——我一点也没觉得丢人。"
         },
         "24022": {
             "Name": "Vran Warrior",
-            "Info": "Deploy: Consume the unit to the right and boost self by its power. Every 2 turns, on turn start, repeat its deploy ability.",
+            "Info": "Deploy: Consume the unit to the right and boost self by its power.\nEvery 2 turns, on turn start, repeat its deploy ability.",
             "Flavor": "他们静静地骑在马上，看起来很放松，但全副武装：宽头短矛、剑柄独特的剑、战斧以及锯齿长斧。"
         },
         "24023": {
             "Name": "Wyvern",
-            "Info": "Deploy: Deal 5 damage.",
+            "Info": "Deploy: Deal 5 damage to an enemy.",
             "Flavor": "想象一下在最可怕的噩梦中出现的长翅膀的蛇——翼手龙比这更可怕。"
         },
         "24024": {
             "Name": "Lamia",
-            "Info": "Deploy: Deal 4 damage to an enemy. If the enemy is under Blood Moon, deal 7 damage instead.",
+            "Info": "Deploy: Deal 4 damage to an enemy.\nIf the enemy is under Blood Moon, deal 7 damage instead.",
             "Flavor": "有个迷信的家伙用蜡堵住耳朵，结果什么也听不到，包括警告——他的船直接撞上了礁石。"
         },
         "24025": {
             "Name": "Barbegazi",
-            "Info": "Deploy: Consume an ally and boost self by its power. Resilient.",
+            "Info": "Deploy: Consume an ally and boost self by its power.\nResilient.",
             "Flavor": "岩洞中先前还和石头没什么两样的怪物，倏地瞪大眼睛，充满恶意地盯着他。"
         },
         "24026": {
@@ -1223,7 +1223,7 @@
         },
         "24029": {
             "Name": "Ghoul",
-            "Info": "Deploy: Consume a Bronze or Silver Unit from your Graveyard. ",
+            "Info": "Deploy: Consume a Bronze or Silver unit from your graveyard. ",
             "Flavor": "如果食尸鬼也是生死循环的一环……那这循环也太残酷了。"
         },
         "24030": {
@@ -1233,12 +1233,12 @@
         },
         "24031": {
             "Name": "Nekker",
-            "Info": "Whenever you Consume a card, boost this unit by 1, wherever it is.\nDeathwish: Play a copy of this unit from your deck.",
+            "Info": "Whenever you consume a card, boost this unit by 1 if in hand, deck or on board.\nDeathwish: Play a copy of this unit from your deck.",
             "Flavor": "如果忽略它们会攻击人类的残酷事实，这些小家伙其实挺可爱的。"
         },
         "24032": {
             "Name": "Wild Hunt Hound",
-            "Info": "Deploy: Play a Biting Frost card from your Deck.",
+            "Info": "Deploy: Play Biting Frost from your Deck.",
             "Flavor": "下令出动，放狗开战。"
         },
         "24033": {
@@ -1248,7 +1248,7 @@
         },
         "24034": {
             "Name": "Ice Troll",
-            "Info": "Deploy: Duel an enemy. If it is under Frost, deal double damage.",
+            "Info": "Deploy: Duel an enemy.\nIf the enemy is under Biting Frost, deal double damage.",
             "Flavor": "巨魔形形色色，身材、嗜好各有不同。不过它们的脑子都和一桶锈钉子差不了多少。"
         },
         "24035": {
@@ -1268,7 +1268,7 @@
         },
         "24038": {
             "Name": "Moonlight",
-            "Info": "Choose One: Apply a Full Moon Boon; or Apply a Blood Moon Hazard.",
+            "Info": "Choose One: Apply a Full Moon Boon; or apply a Blood Moon Hazard.",
             "Flavor": "满月的时候，梦魇便会从世界的各个角落匍匐而出。"
         },
         "25001": {
@@ -1288,7 +1288,7 @@
         },
         "25004": {
             "Name": "Harpy Egg",
-            "Info": "When Consumed by another Unit, Boost that Unit by an additional 5.\nDeathwish: Spawn a Harpy on a random row.",
+            "Info": "When consumed by another unit, boost that unit by an additional 5 points.\nDeathwish: Spawn a Harpy Hatchling on a random row.",
             "Flavor": "鹰身女妖蛋卷，真是美味佳肴啊，好先生。但它也非常昂贵，您可能料得到，这些可怜的鸟儿并不愿跟自己的蛋分离。"
         },
         "25005": {
@@ -1333,7 +1333,7 @@
         },
         "31004": {
             "Name": "Usurper",
-            "Info": "Spying. Deploy: Create any Leader and boost it by 2.",
+            "Info": "Spying.\nDeploy: Create any Leader and boost it by 2.",
             "Flavor": "王权怎能单凭出身的贵贱来随便决定？"
         },
         "32002": {
@@ -1343,7 +1343,7 @@
         },
         "32003": {
             "Name": "Vattier de Rideaux",
-            "Info": "Deploy: Reveal up to 2 of your cards, then Reveal the same number of your opponent's randomly.",
+            "Info": "Deploy: reveal up to 2 of your cards, then reveal the same number of your opponent's randomly.",
             "Flavor": "精心策划的暗算能解决所有麻烦。"
         },
         "32004": {
@@ -1353,22 +1353,22 @@
         },
         "32005": {
             "Name": "Tibor Eggebracht",
-            "Info": "Deploy, Truce: Boost self by 15, then your opponent draws a Revealed Bronze card.",
+            "Info": "Deploy, Truce: Boost self by 15, then your opponent draws a revealed Bronze card.",
             "Flavor": "蒂博尔以狂热的忠诚而闻名。据说皇帝驾崩时，他深深地鞠躬致敬，几乎可以说贴在了地上。"
         },
         "32006": {
             "Name": "Vilgefortz",
-            "Info": "Deploy: Destroy an ally, then play a card from your deck; or Truce: Destroy an enemy, then your opponent draws a Revealed Bronze card.",
+            "Info": "Deploy: Destroy an ally, then play a card from your deck; or Truce: Destroy an enemy, then your opponent draws a revealed Bronze card.",
             "Flavor": "我们都是他棋盘上的棋子，而这棋局的规则，我们一无所知。"
         },
         "32007": {
             "Name": "Shilard",
-            "Info": "Single-Use. Deploy, Truce: Draw a card from both decks. Keep one and give the other to your opponent.",
+            "Info": "Single-Use.\nDeploy, Truce: Draw a card from both decks.\nKeep one and give the other to your opponent.",
             "Flavor": "所谓外交官，就是用华丽的辞藻，来透露一些只言片语。"
         },
         "32008": {
             "Name": "Menno Coehoorn",
-            "Info": "Deploy: Damage an Enemy by 4. If it is Spying, Destroy it. ",
+            "Info": "Deploy: Damage an enemy by 4.\nIf it is Spying, destroy it. ",
             "Flavor": "细心的侦察分队比训练有素的军团更管用。"
         },
         "32009": {
@@ -1388,7 +1388,7 @@
         },
         "32011": {
             "Name": "Letho: Kingslayer",
-            "Info": "Deploy, Choose One: Destroy an enemy Leader, then boost self by 5; or Play a Bronze or Silver Tactic from your deck.",
+            "Info": "Deploy, Choose One: Destroy an enemy Leader, then boost self by 5; or play a Bronze or Silver Tactic from your deck.",
             "Flavor": "这僧侣为什么戴着镶钉手套……？"
         },
         "32012": {
@@ -1403,7 +1403,7 @@
         },
         "32014": {
             "Name": "Letho of Gulet",
-            "Info": "Double agent. Deploy: Toggle 2 units' Lock on the row, then Drain all their power.",
+            "Info": "Double agent.\nDeploy: Toggle 2 units' Lock on the same row, then drain all their power.",
             "Flavor": "猎魔人绝不会死在自己的床上。"
         },
         "32015": {
@@ -1413,7 +1413,7 @@
         },
         "33004": {
             "Name": "Cantarella",
-            "Info": "Spying. Single-Use. Deploy: Draw 2 cards. Keep one and move the other to the bottom of your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Draw 2 cards.\nKeep one and move the other to the bottom of your deck.",
             "Flavor": "男人渴望着诱惑，神秘加优雅往往事半功倍。"
         },
         "33005": {
@@ -1428,7 +1428,7 @@
         },
         "33006": {
             "Name": "Albrich",
-            "Info": "Single-Use. Deploy, Truce: Each player draws a card. The opponent's card is Revealed.",
+            "Info": "Single-Use.\nDeploy, Truce: Each player draws a card.\nThe opponent's card is Revealed.",
             "Flavor": "火球？没问题。陛下想要什么都行。"
         },
         "33007": {
@@ -1438,17 +1438,17 @@
         },
         "33008": {
             "Name": "Henry var Attre",
-            "Info": "Deploy: Conceal any number of units. If allies, boost by 2. If enemies, deal 2 damage.",
+            "Info": "Deploy: Conceal any number of units.\nIf allies, boost by 2.\nIf enemies, deal 2 damage.",
             "Flavor": "我在诺维格瑞驻守了十三年，什么我没见过？残忍、讥嘲、贪欲。可如今发生的事情却让我极度不安"
         },
         "33002": {
             "Name": "False Ciri",
-            "Info": "Spying. If Spying, boost self by 1 on turn start and when your opponent passes, move to the opposite row.\nDeathwish: Destroy the Lowest unit on the row.",
+            "Info": "Spying.\nIf Spying, boost self by 1 on turn start and when your opponent passes, move to the opposite row.\nDeathwish: Destroy the Lowest unit on the row.",
             "Flavor": "“她来了，”他心想，“皇帝的联姻对象。冒牌公主、冒牌的辛特拉女王、冒牌的雅鲁加河口统治者，也是帝国未来的命脉。”"
         },
         "33009": {
             "Name": "Hefty Helge",
-            "Info": "Deploy: If this unit was Revealed, Damage all Enemies by 1. Otherwise, Damage all enemies except those on opposite row by 1.",
+            "Info": "Deploy: Deal 1 damage to all enemies except those on the opposite row.\nIf this unit was revealed, deal 1 damage to all enemies instead.",
             "Flavor": "并非攻城的最佳选择，却是毁城的行家里手。"
         },
         "33010": {
@@ -1458,22 +1458,22 @@
         },
         "33011": {
             "Name": "Peter Saar Gwynleve",
-            "Info": "Deploy, Choose One: Reset an ally and Strengthen it by 3; or Reset an enemy and Weaken it by 3.",
+            "Info": "Deploy, Choose One: Reset an ally and strengthen it by 3; or reset an enemy and weaken it by 3.",
             "Flavor": "这双手不属于什么“阁下”，只属于一介农夫。所以这是农夫与农夫间的对话。"
         },
         "33012": {
             "Name": "Serrit",
-            "Info": "Deploy, Choose One: Deal 7 damage to an enemy or set a Revealed opposing unit to 1.",
+            "Info": "Deploy, Choose One: Deal 7 damage to an enemy or set a revealed opposing unit to 1.",
             "Flavor": "这是我们必须做的，我并不为此感到羞愧。"
         },
         "33013": {
             "Name": "Cynthia",
-            "Info": "Deploy: Reveal the Highest unit in your opponent's Hand and Boost self by its Power.",
+            "Info": "Deploy: Reveal the Highest unit in your opponent's hand and boost self by its power.",
             "Flavor": "决不能轻视辛西亚，必须把她看紧点儿。"
         },
         "33001": {
             "Name": "Joachim de Wett",
-            "Info": "Spying. Deploy: Play the top non-Spying Bronze or Silver unit from your deck and boost it by 10.",
+            "Info": "Spying.\nDeploy: Play the top non-Spying Bronze or Silver unit from your deck and boost it by 10.",
             "Flavor": "即便用“无能”来形容德·维特公爵对维登集团军的领导，都算给他面子"
         },
         "33014": {
@@ -1483,12 +1483,12 @@
         },
         "33015": {
             "Name": "Vanhemar",
-            "Info": "Deploy: Spawn Frost, Clear Skies or Shrike.",
+            "Info": "Deploy: Spawn Biting Frost, Clear Skies or Shrike.",
             "Flavor": "作为火法师，他算不上……多么热烈。"
         },
         "33016": {
             "Name": "Vreemde",
-            "Info": "Deploy: Create a Bronze Nilfgaardian Soldier.",
+            "Info": "Deploy: Create a Bronze Nilfgaard Soldier.",
             "Flavor": "即便要击败你们每一个人，我也要让伟大日轮照耀北境。"
         },
         "33017": {
@@ -1498,7 +1498,7 @@
         },
         "33018": {
             "Name": "Fringilla Vigo",
-            "Info": "Double agent. Deploy: Copy the power from the unit to the left to the unit to the right.",
+            "Info": "Double agent.\nDeploy: Copy the power from the unit to the left to the unit to the right.",
             "Flavor": "魔法的价值高于一切，高于所有争论和敌意。"
         },
         "33019": {
@@ -1508,7 +1508,7 @@
         },
         "33020": {
             "Name": "Treason",
-            "Info": "Force 2 adjacent enemies to Duel each other.",
+            "Info": "Force 2 adjacent enemies to duel each other.",
             "Flavor": "许多人相信，帝国的实力在于纪律严明的军队与恪尽职守的法师。但事实上，金钱才是尼弗迦德统治世界的关键。"
         },
         "33021": {
@@ -1528,7 +1528,7 @@
         },
         "34004": {
             "Name": "Nilfgaardian Knight",
-            "Info": "Deploy: Reveal a random card in your hand. 2 Armor.",
+            "Info": "Deploy: Reveal a random card in your hand.\n2 Armor.",
             "Flavor": "出自名门望族，生于金塔之城，组成帝国的精锐部队。"
         },
         "34006": {
@@ -1583,22 +1583,22 @@
         },
         "34016": {
             "Name": "Mangonel",
-            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you Reveal a card.",
+            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you reveal a card.",
             "Flavor": "适用于投掷残骸和干粪。"
         },
         "34017": {
             "Name": "Nauzicaa Sergeant",
-            "Info": "Deploy: Clear Hazards from its row and boost an ally or a Revealed unit by 3.",
+            "Info": "Deploy: Clear Hazards from its row and boost an ally or a revealed unit by 3.",
             "Flavor": "皇帝会教北方人懂点儿规矩的。"
         },
         "34018": {
             "Name": "Combat Engineer",
-            "Info": "Deploy: Toggle Resilience of a friendly unit. Crew.",
+            "Info": "Deploy: Toggle Resilience of an ally.\nCrew.",
             "Flavor": "战争是文明进步的确凿证据——看看吧，现在大伙儿打仗更有效率了。"
         },
         "34003": {
             "Name": "Impera Brigade",
-            "Info": "Deploy: Boost self by 2 for each Spying Enemy.\nWhenever a Spying Enemy appears, Boost self by 2.",
+            "Info": "Deploy: Boost self by 2 for each Spying Enemy.\nWhenever a Spying Enemy appears, boost self by 2.",
             "Flavor": "近卫军绝不投降，绝不。"
         },
         "34005": {
@@ -1608,17 +1608,17 @@
         },
         "34019": {
             "Name": "Fire Scorpion",
-            "Info": "Deploy: Deal 5 damage to an enemy.\nWhenever you Reveal this unit, trigger its ability.",
+            "Info": "Deploy: Deal 5 damage to an enemy.\nWhenever you reveal this unit, trigger its ability.",
             "Flavor": "名字与实物可谓风马牛不相及，听上去它好像是某种肥大的红色甲壳生物，但其实是一种由能工巧匠精心设计的大规模杀伤性武器……"
         },
         "34020": {
             "Name": "Nauzicaa Brigade",
-            "Info": "Deploy: Damage a Spying unit by 7. If it was Destroyed, Strengthen self by 4.",
+            "Info": "Deploy: Damage a Spying unit by 7.\nIf it was destroyed, strengthen self by 4.",
             "Flavor": "我们被称作死神头。想知道为什么吗？"
         },
         "34021": {
             "Name": "Spotter",
-            "Info": "Deploy: Choose a Bronze or Silver Revealed unit in either Hand and boost self by its base Power.",
+            "Info": "Deploy: Choose a Bronze or Silver Revealed unit in either hand and boost self by its base power.",
             "Flavor": "北方佬耍不出花招了。"
         },
         "34022": {
@@ -1628,17 +1628,17 @@
         },
         "34023": {
             "Name": "Daerlan Soldier",
-            "Info": "Whenever you Reveal this unit, play it on a random row and draw a card.",
+            "Info": "Whenever you reveal this unit, play it on a random row and draw a card.",
             "Flavor": "我在布莱班特军事学院学到了不少东西，比如洗土豆"
         },
         "34024": {
             "Name": "Alba Pikeman",
-            "Info": "At the beginning of the round, summon one copy from the deck. 2 armor.",
+            "Info": "At the beginning of the round, summon one copy from the deck.\n2 armor.",
             "Flavor": "宣誓效忠吾皇恩希尔·恩瑞斯……不然就受刑吧！"
         },
         "34025": {
             "Name": "Imperial Golem",
-            "Info": "Summon a copy of this unit whenever you Reveal a card in your opponent's hand. ",
+            "Info": "Summon a copy of this unit whenever you reveal a card in your opponent's hand. ",
             "Flavor": "尼弗迦德最强大的法师们终于成功掌握了制造魔像的方法。更棒的是，他们已经“偶尔”能让这些魔像为帝国而战了……"
         },
         "34026": {
@@ -1653,22 +1653,22 @@
         },
         "34028": {
             "Name": "Ambassador",
-            "Info": "Spying. Deploy: Boost an ally by 14.",
+            "Info": "Spying.\nDeploy: Boost an ally by 14.",
             "Flavor": "间谍？不，这么说就太过啦。我觉得自己不过是个观察员而已。"
         },
         "34002": {
             "Name": "Emissary",
-            "Info": "Spying. Deploy: Look at 2 random Bronze units from your deck, then play 1.",
+            "Info": "Spying.\nDeploy: Look at 2 random Bronze units from your deck, then play 1.",
             "Flavor": "但是……这样不对啊！两国交兵不斩来使！"
         },
         "34001": {
             "Name": "Vicovaro Novice",
-            "Info": "Deploy: Draw the top 2 Bronze Alchemy cards from your Deck. Play 1 and shuffle the other back.",
+            "Info": "Deploy: Draw the top 2 Bronze Alchemy cards from your Deck.\nPlay 1 and shuffle the other back.",
             "Flavor": "尼弗迦德的法师们就像手纸。一旦谁被皇帝厌倦，立刻有大把新人迫不及待地赶来补缺。"
         },
         "34029": {
             "Name": "Assassin",
-            "Info": "Spying. Deploy: Deal 10 damage to the unit to the left.",
+            "Info": "Spying.\nDeploy: Deal 10 damage to the unit to the left.",
             "Flavor": "帝国宫廷最受欢迎的职业之一，仅次于抄书吏和轻浮的贵妇。"
         },
         "34030": {
@@ -1678,7 +1678,7 @@
         },
         "34031": {
             "Name": "Venendal Elite",
-            "Info": "Deploy: Switch this unit's power with that of a Revealed unit.",
+            "Info": "Deploy: Switch this unit's power with that of a revealed unit.",
             "Flavor": "艾宾以其顶尖的雇佣兵和轻骑兵闻名天下。"
         },
         "34032": {
@@ -1703,7 +1703,7 @@
         },
         "41001": {
             "Name": "King Radovid V",
-            "Info": "Deploy: Toggle 2 units' Lock statuses. If enemies, deal 5 damage to them. Crew.",
+            "Info": "Deploy: Toggle 2 units' Lock statuses.\nIf enemies, deal 5 damage to them.\nCrew.",
             "Flavor": "身为国王，对待敌人应冷酷无情，对待朋友当慷慨大度。"
         },
         "41002": {
@@ -1713,12 +1713,12 @@
         },
         "41003": {
             "Name": "King Foltest",
-            "Info": "Deploy: Boost all other allies and your non-Spying units in hand and deck by 1. Crew.",
+            "Info": "Deploy: Boost all other allies and your non-Spying units in hand and deck by 1.\nCrew.",
             "Flavor": "我不需要谋臣和他们的诡计，我相信士兵的利刃。"
         },
         "41004": {
             "Name": "King Henselt",
-            "Info": "Deploy: Choose a Bronze Machine or Kaedweni ally and play all copies of it from your deck. Crew.",
+            "Info": "Deploy: Choose a Bronze Machine or Kaedweni ally and play all copies of it from your deck.\nCrew.",
             "Flavor": "恕我直言，亨赛特国王不是看起来像贼，他本就是贼。"
         },
         "42001": {
@@ -1728,22 +1728,22 @@
         },
         "42002": {
             "Name": "Bloody Baron",
-            "Info": "Whenever an enemy is destroyed, boost self by 1, wherever it is.",
+            "Info": "Whenever an enemy is destroyed, if in hand, deck, or on board, boost self by 1.",
             "Flavor": "我知道自己不是个好父亲，但……现在弥补或许还来得及。"
         },
         "42003": {
             "Name": "Seltkirk of Gulet",
-            "Info": "Deploy: Duel an enemy. 3 Armor.",
+            "Info": "Deploy: Duel an enemy.\n3 Armor.",
             "Flavor": "尽管赛尔奇克美德过人，更是有着不屈的勇气，然而他还是和所有命丧上亚甸之战的将士一样，没能逃过自己的命运。"
         },
         "42004": {
             "Name": "Vandergrift",
-            "Info": "Deploy: Deal 1 damage to all enemies. If a unit is destroyed, apply Ragh Nar Roog to its row.",
+            "Info": "Deploy: Deal 1 damage to all enemies.\nIf a unit is destroyed, apply Ragh Nar Roog to its row.",
             "Flavor": "将军本以为洛马克的战争会很快结束，不会有什么损失……结果却陷入了永恒的征战。"
         },
         "42005": {
             "Name": "John Natalis",
-            "Info": "Deploy: Play a Bronze or Silver Tactics card from your Deck. Shuffle the others back.",
+            "Info": "Deploy: Play a Bronze or Silver Tactics card from your deck. Shuffle the others back.",
             "Flavor": "那座广场应以我的士兵及其他牺牲者来命名，而不是顶着我的名字。"
         },
         "42006": {
@@ -1758,7 +1758,7 @@
         },
         "42008": {
             "Name": "Sigismund Dijkstra",
-            "Info": "Spying. Deploy: Play 2 random cards from your deck.",
+            "Info": "Spying.\nDeploy: Play 2 random cards from your deck.",
             "Flavor": "你真以为这种下三滥的谎话能糊弄我？"
         },
         "42009": {
@@ -1778,7 +1778,7 @@
         },
         "42012": {
             "Name": "Vernon Roche",
-            "Info": "Deploy: Deal 7 damage.\nAt the start of the game, add a Blue Stripes Commando to your deck.",
+            "Info": "Deploy: Deal 7 damage to an enemy.\nAt the start of the game, add a Blue Stripes Commando to your deck.",
             "Flavor": "一位爱国者……也是个令人头疼的家伙。"
         },
         "42013": {
@@ -1788,7 +1788,7 @@
         },
         "43001": {
             "Name": "Thaler",
-            "Info": "Spying. Single-Use. Deploy: Draw 2 cards, keep one and return the other to your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Draw 2 cards, keep one and shuffle the other back to your deck.",
             "Flavor": "滚开！我们中间不是每个人都那么轻浮、那么浅薄……"
         },
         "43002": {
@@ -1798,12 +1798,12 @@
         },
         "43003": {
             "Name": "Trollololo",
-            "Info": "At the start of your turn, gain 2 Armor. 4 Armor.",
+            "Info": "At the start of your turn, gain 2 Armor.\n4 Armor.",
             "Flavor": "我是拉多多德国王的兵兵。收到命令，看守船船。"
         },
         "43004": {
             "Name": "Ronvid the Incessant",
-            "Info": "On turn end, Resurrect on a random row with 1 power. Crew.",
+            "Info": "On turn end, resurrect on a random row with 1 power.\nCrew.",
             "Flavor": "这位自封的骑士四海漂泊，捍卫着心爱少女比贝莉的荣誉。虽然没人知道她住在哪里，她是不是哈活着，甚至是不是曾经有过这个人。"
         },
         "43005": {
@@ -1818,7 +1818,7 @@
         },
         "43007": {
             "Name": "Foltest's Pride",
-            "Info": "Deploy: Damage an enemy by 3 and move it to the row above. Crewed: Repeat its ability.",
+            "Info": "Deploy: Damage an enemy by 3 and move it to the row above.\nCrewed: Repeat its ability.",
             "Flavor": "正如弗尔泰斯特国王常说的那样，尺寸并不重要，关键要好用。"
         },
         "43008": {
@@ -1828,7 +1828,7 @@
         },
         "43009": {
             "Name": "Odrin",
-            "Info": "On turn start, move to a random row and boost all allies on it by 1. \nDeathwish: boost all allies on the same row by 1.",
+            "Info": "On turn start, move to a random row and boost all allies on it by 1.\nDeathwish: boost all allies on the same row by 1.",
             "Flavor": "喝酒少了欧德林，就像划船没带桨。"
         },
         "43010": {
@@ -1853,7 +1853,7 @@
         },
         "43014": {
             "Name": "Síle de Tansarville",
-            "Info": "Deploy: Play a Bronze or Silver special card from your hand, then draw a card.",
+            "Info": "Deploy: Play a Bronze or Silver Special card from your hand, then draw a card.",
             "Flavor": "女术士集会所缺乏谦逊，对权力的渴望可能会让我们功亏一篑。"
         },
         "43015": {
@@ -1863,12 +1863,12 @@
         },
         "43016": {
             "Name": "Prince Stennis",
-            "Info": "Deploy: Play a random non-Spying Bronze or Silver unit from your deck and give it 5 Armor. 3 Armor.",
+            "Info": "Deploy: Play a random non-Spying Bronze or Silver unit from your deck and give it 5 Armor.\n3 Armor.",
             "Flavor": "他穿着黄金铠甲——没错，混账一个。"
         },
         "43017": {
             "Name": "Sabrina Glevissig",
-            "Info": "Spying. Deathwish: Set the power of all units on the row to the power of the Lowest unit on the row.",
+            "Info": "Spying.\nDeathwish: Set the power of all units on the row to the power of the Lowest unit on the row.",
             "Flavor": "科德温荒野之女。"
         },
         "43018": {
@@ -1888,7 +1888,7 @@
         },
         "43021": {
             "Name": "Vandergrift's Blade",
-            "Info": "Choose One: Destroy a Bronze or Silver Cursed enemy; or Deal 10 damage. If the unit was destroyed, Banish it.",
+            "Info": "Choose One: Destroy a Bronze or Silver Cursed enemy; or deal 10 damage.\nIf the unit was destroyed, banish it.",
             "Flavor": "在阿德卡莱的一次骑士比武中，赛尔奇克打断了范德格里夫特的长剑。于是，愤怒的范德格里夫特下令铸造一把新的兵刃，还在上面附了强大的符文石。"
         },
         "44001": {
@@ -1898,12 +1898,12 @@
         },
         "44002": {
             "Name": "Ban Ard Tutor",
-            "Info": "Deploy: Swap a card in your hand with a Bronze special card from your deck.",
+            "Info": "Deploy: Swap a card in your hand with a Bronze Special card from your deck.",
             "Flavor": "我一直拿艾瑞图萨学院的女生和班·阿德的愣头小子们作对比。结果总是姑娘们胜出。"
         },
         "44003": {
             "Name": "Kaedweni Sergeant",
-            "Info": "Deploy: Clear Hazards from its row. 3 Armor. Crew.",
+            "Info": "Deploy: Clear Hazards from its row.\nCrew.\n3 Armor.",
             "Flavor": "冲锋，没用的蠢货！冲锋，不然你就会知道，我比尼弗迦德人更可怕！"
         },
         "44004": {
@@ -1918,32 +1918,32 @@
         },
         "44006": {
             "Name": "Redanian Elite",
-            "Info": "Whenever this unit's Armor reaches 0, boost self by 5. 4 Armor.",
+            "Info": "Whenever this unit's Armor reaches 0, boost self by 5.\n4 Armor.",
             "Flavor": "为了瑞达尼亚，不论上刀山下油锅，还是吃虫子，我都在所不惜。"
         },
         "44007": {
             "Name": "Siege Tower",
-            "Info": "Deploy: Boost self by 2. Crewed: Repeat its ability.",
+            "Info": "Deploy: Boost self by 2.\nCrewed: Repeat its ability.",
             "Flavor": "攻城用的最新武器。"
         },
         "44008": {
             "Name": "Reinforced Trebuchet",
-            "Info": "On turn end, Deal 1 damage to a random enemy.",
+            "Info": "On turn end, deal 1 damage to a random enemy.",
             "Flavor": "感受到了吗？每当这宝贝儿投出巨石，大地都会震颤。"
         },
         "44009": {
             "Name": "Kaedweni Knight",
-            "Info": "Boost this unit by 5 if played from the deck. 2 Armor.",
+            "Info": "Boost this unit by 5 if played from the deck.\n2 Armor.",
             "Flavor": "科德温军队里并非所有人都认同国王的政治手段。然而谁都不敢说出来。"
         },
         "44010": {
             "Name": "Cursed Knight",
-            "Info": "Deploy: Transform a Cursed ally into a copy of this unit. 2 Armor.",
+            "Info": "Deploy: Transform a Cursed ally into a copy of this unit.\n2 Armor.",
             "Flavor": "深陷无尽的战斗，却早已忘记了起因。"
         },
         "44011": {
             "Name": "Siege Support",
-            "Info": "Whenever an ally appears, boost it by 1. If it's a Machine, also give it 1 Armor. Crew.",
+            "Info": "Whenever an ally appears, boost it by 1. If it's a Machine, also give it 1 Armor.\nCrew.",
             "Flavor": "“你得把准星左校5度。”“把什么调多少？”"
         },
         "44012": {
@@ -1953,17 +1953,17 @@
         },
         "44013": {
             "Name": "Redanian Knight-Elect",
-            "Info": "On turn end, if this unit has Armor, boost adjacent units by 1. 2 Armor.",
+            "Info": "On turn end, if this unit has Armor, boost adjacent units by 1.\n2 Armor.",
             "Flavor": "不为名不为利，高尚的动机才能成就英雄！"
         },
         "44014": {
             "Name": "Reinforced Ballista",
-            "Info": "Deploy: Damage an Enemy by 2. \nCrewed: Repeat the Deploy ability.",
+            "Info": "Deploy: Damage an Enemy by 2. \nCrewed: Repeat its ability.",
             "Flavor": "从没两次命中同一处，仔细想想，真是个大问题。"
         },
         "44015": {
             "Name": "Trebuchet",
-            "Info": "Deploy: Damage 3 Adjacent Enemies by 1. \nCrewed: Increase the Damage dealt by 1.",
+            "Info": "Deploy: Damage 3 adjacent enemies by 1.\nCrewed: Increase the damage dealt by 1.",
             "Flavor": "城堡可是块硬骨头。快去准备投石机！"
         },
         "44016": {
@@ -1973,17 +1973,17 @@
         },
         "44017": {
             "Name": "Ballista",
-            "Info": "Deploy: Damage an Enemy and up to 4 other random Enemies with the same Power by 1. \nCrewed: Repeat the Deploy ability.",
+            "Info": "Deploy: Damage an Enemy and up to 4 other random Enemies with the same Power by 1.\nCrewed: Repeat its ability.",
             "Flavor": "成为弩炮是所有十字弩的终极梦想。"
         },
         "44018": {
             "Name": "Battering Ram",
-            "Info": "Deploy: Deal 3 damage. If the unit was destroyed, deal 3 damage to another unit. \nCrewed: Increase initial damage by 1.",
+            "Info": "Deploy: Deal 3 damage.\nIf the unit was destroyed, deal 3 damage to another unit.\nCrewed: Increase initial damage by 1.",
             "Flavor": "不肯开门是吧？那我们就再加把劲敲一敲啰。"
         },
         "44019": {
             "Name": "Siege Master",
-            "Info": "Deploy: Heal an allied Bronze or Silver Machine and repeat its ability. Crew.",
+            "Info": "Deploy: Heal an allied Bronze or Silver Machine and repeat its ability.\nCrew.",
             "Flavor": "我绝不会失手两次。"
         },
         "44020": {
@@ -1993,7 +1993,7 @@
         },
         "44021": {
             "Name": "Reaver Hunter",
-            "Info": "Deploy: Boost all copies of this unit by 1, wherever they are. Repeat its ability whenever a copy of this unit is played.",
+            "Info": "Deploy: Boost all copies of this unit by 1, if in hand, deck or on board. Repeat its ability whenever a copy of this unit is played.",
             "Flavor": "看见这纹身没？纹的是我在痛扁一条龙。一条龙哟，女士。"
         },
         "44022": {
@@ -2003,7 +2003,7 @@
         },
         "44023": {
             "Name": "Dun Banner Light Cavalry",
-            "Info": "On turn start, if you are losing by more than 25, Summon this unit to a random row.",
+            "Info": "On turn start, if you are losing by more than 25 points, summon this unit to a random row.",
             "Flavor": "冷静，所有人保持警惕！这可能是那帮披斗篷戴海狸皮帽的家伙的陷阱……"
         },
         "44024": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -903,7 +903,7 @@
         },
         "22001": {
             "Name": "Old Speartip: Asleep",
-            "Info": "Deploy: Strengthen all your other Ogroids in hand, deck and on board by 1.",
+            "Info": "Deploy: Strengthen all your other Ogroids in hand, deck and on the board by 1.",
             "Flavor": "别吵！"
         },
         "22002": {
@@ -923,7 +923,7 @@
         },
         "22005": {
             "Name": "Imlerith",
-            "Info": "Deploy: Damage an enemy by 4.\nIf the enemy is under a Frost Hazard, Destory it instead.",
+            "Info": "Deploy: Damage an enemy by 4.\nIf the enemy is under Biting Frost, Destroy it instead.",
             "Flavor": "叫他们有来无回！"
         },
         "22006": {
@@ -958,7 +958,7 @@
         },
         "22012": {
             "Name": "Weavess: Incantation",
-            "Info": "Deploy, Choose One: Strengthen allied Relicts by 2, wherever they are; or Play a Bronze or Silver Relict from your deck and Strengthen it by 2.",
+            "Info": "Deploy, Choose One: Strengthen all your Relicts in hand, deck and on the board by 2; or Play a Bronze or Silver Relict from your deck and Strengthen it by 2.",
             "Flavor": "我能感受到你的痛苦和恐惧。"
         },
         "22013": {
@@ -988,17 +988,17 @@
         },
         "23004": {
             "Name": "Brewess",
-            "Info": "Deploy: Summon Whispess and Weavess",
+            "Info": "Deploy: Summon Whispess and Weavess.",
             "Flavor": "切烂……剁碎……然后熬出……一锅好汤。"
         },
         "23005": {
             "Name": "Colossal Ifrit",
-            "Info": "Deploy: Spawn 3 Lesser Ifrits to the right of this unit.",
+            "Info": "Deploy: Spawn 3 copies of Lesser Ifrit to the right of this unit.\n(When Summoned, deal 1 Damage to a random enemy)",
             "Flavor": "受不了热浪？那就没生路了。"
         },
         "23006": {
             "Name": "Ruehin",
-            "Info": "Deploy: Strengthen all your Insectoid and Cursed units by 1, wherever they are.",
+            "Info": "Deploy: Strengthen all your Insectoid and Cursed units in hand, deck and on the board by 1.",
             "Flavor": "进入那片森林的人，没一个活着回来……"
         },
         "23007": {
@@ -1063,7 +1063,7 @@
         },
         "23019": {
             "Name": "She-Troll of Vergen",
-            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, Consume it and Boost self by its base Power",
+            "Info": "Deploy: Play a Bronze Deathwish unit from your deck, Consume it and Boost self by its base Power.",
             "Flavor": "着迷于精灵洋葱汤。"
         },
         "23020": {
@@ -1218,7 +1218,7 @@
         },
         "24028": {
             "Name": "Foglet",
-            "Info": "Whenever you apply Fog to an enemy row, Summon a copy of this unit from your deck to the oppoite row.",
+            "Info": "Whenever you apply Impenetrable Fog to an enemy row, Summon a copy of this unit from your deck to the oppoite row.",
             "Flavor": "浓雾悄然弥漫时，小雾妖便会出没，来享用它们的受害者。"
         },
         "24029": {
@@ -1233,7 +1233,7 @@
         },
         "24031": {
             "Name": "Nekker",
-            "Info": "Whenever you Consume a card, Boost this unit by 1 if in hand, deck or on board.\nDeathwish: Play a copy of this unit from your deck.",
+            "Info": "Whenever you Consume a card, Boost this unit by 1 if in hand, deck or on the board.\nDeathwish: Play a copy of this unit from your deck.",
             "Flavor": "如果忽略它们会攻击人类的残酷事实，这些小家伙其实挺可爱的。"
         },
         "24032": {
@@ -1343,7 +1343,7 @@
         },
         "32003": {
             "Name": "Vattier de Rideaux",
-            "Info": "Deploy: Reveal up to 2 of your cards, then Reveal the same number of your opponent's randomly.",
+            "Info": "Deploy: Reveal up to 2 cards from your hand.\nFor each, Reveal 1 random card from your opponent's hand.",
             "Flavor": "精心策划的暗算能解决所有麻烦。"
         },
         "32004": {
@@ -1403,7 +1403,7 @@
         },
         "32014": {
             "Name": "Letho of Gulet",
-            "Info": "Double agent.\nDeploy: Toggle 2 units' Lock on the same row, then Drain all their Power.",
+            "Info": "Double Agent.\nDeploy: Toggle 2 units' Lock on the same row, then Drain all their Power.",
             "Flavor": "猎魔人绝不会死在自己的床上。"
         },
         "32015": {
@@ -1433,17 +1433,17 @@
         },
         "33007": {
             "Name": "Sweers",
-            "Info": "Deploy: Choose an enemy or a Revealed unit in your opponent's hand, then move all copies of it from from their deck to the graveyard.",
+            "Info": "Deploy: Choose an enemy or a Revealed unit in your opponent's hand, then move all copies of it from their deck to the graveyard.",
             "Flavor": "别碰那女孩！听明白没，你们这群乡巴佬？"
         },
         "33008": {
             "Name": "Henry var Attre",
-            "Info": "Deploy: Conceal any number of units.\nIf allies, Boost by 2.\nIf enemies, deal 2 Damage.",
+            "Info": "Deploy: Conceal any number of units.\nIf allies, Boost them by 2.\nIf enemies, deal 2 Damage to them.",
             "Flavor": "我在诺维格瑞驻守了十三年，什么我没见过？残忍、讥嘲、贪欲。可如今发生的事情却让我极度不安"
         },
         "33002": {
             "Name": "False Ciri",
-            "Info": "Spying.\nIf Spying, Boost self by 1 on turn start and when your opponent passes, move to the opposite row.\nDeathwish: Destroy the Lowest unit on the row.",
+            "Info": "Spying.\nIf Spying, on turn start, Boost self by 1.\nWhen your opponent passes, move to the opposite row.\nDeathwish: Destroy the Lowest unit on the row.",
             "Flavor": "“她来了，”他心想，“皇帝的联姻对象。冒牌公主、冒牌的辛特拉女王、冒牌的雅鲁加河口统治者，也是帝国未来的命脉。”"
         },
         "33009": {
@@ -1488,7 +1488,7 @@
         },
         "33016": {
             "Name": "Vreemde",
-            "Info": "Deploy: Create a Bronze Nilfgaard Soldier.",
+            "Info": "Deploy: Create a Bronze Nilfgaardian Soldier.",
             "Flavor": "即便要击败你们每一个人，我也要让伟大日轮照耀北境。"
         },
         "33017": {
@@ -1498,7 +1498,7 @@
         },
         "33018": {
             "Name": "Fringilla Vigo",
-            "Info": "Double agent.\nDeploy: Copy the Power from the unit to the left to the unit to the right.",
+            "Info": "Double Agent.\nDeploy: Copy the Power from the unit to the left to the unit to the right.",
             "Flavor": "魔法的价值高于一切，高于所有争论和敌意。"
         },
         "33019": {
@@ -1513,7 +1513,7 @@
         },
         "33021": {
             "Name": "Cadaverine",
-            "Info": "Choose One: Deal 3 Damage to an enemy and all units that share its categories; or destroy a Bronze or Silver Neutral unit.",
+            "Info": "Choose One: Deal 3 Damage to an enemy and all units that share its categories; or destroy a Bronze or Silver Neutral enemy.",
             "Flavor": "我不会拿自己的性命去碰运气。我会拿上一把长剑，厚厚地涂上一层吊死鬼之毒。"
         },
         "33022": {
@@ -1533,7 +1533,7 @@
         },
         "34006": {
             "Name": "Master of Disguise",
-            "Info": "Deploy: Conceal 2 cards.",
+            "Info": "Deploy: Conceal up to 2 cards.",
             "Flavor": "哦，高悬上苍的伟大日轮啊，把我们从裤腿里除之不尽的虱子中解救出来吧！"
         },
         "34007": {
@@ -1548,7 +1548,7 @@
         },
         "34009": {
             "Name": "Alchemist",
-            "Info": "Deploy: Reveal 2 cards.",
+            "Info": "Deploy: Reveal up to 2 cards.",
             "Flavor": "两盎司钙素，一盎司结合剂……"
         },
         "34010": {
@@ -1633,7 +1633,7 @@
         },
         "34024": {
             "Name": "Alba Pikeman",
-            "Info": "At the beginning of the round, Summon one copy from the deck.\n2 Armor.",
+            "Info": "After 1 turn, on turn start, Summon a copy of this unit on its row.\n2 Armor.",
             "Flavor": "宣誓效忠吾皇恩希尔·恩瑞斯……不然就受刑吧！"
         },
         "34025": {
@@ -1728,7 +1728,7 @@
         },
         "42002": {
             "Name": "Bloody Baron",
-            "Info": "Whenever an enemy is destroyed, if in hand, deck, or on board, Boost self by 1.",
+            "Info": "Whenever an enemy is destroyed, if in hand, deck, or on the board, Boost self by 1.",
             "Flavor": "我知道自己不是个好父亲，但……现在弥补或许还来得及。"
         },
         "42003": {
@@ -1798,7 +1798,7 @@
         },
         "43003": {
             "Name": "Trollololo",
-            "Info": "At the start of your turn, gain 2 Armor.\n4 Armor.",
+            "Info": "Every turn, at the start of the turn, gain 2 Armor.\n4 Armor.",
             "Flavor": "我是拉多多德国王的兵兵。收到命令，看守船船。"
         },
         "43004": {
@@ -1888,7 +1888,7 @@
         },
         "43021": {
             "Name": "Vandergrift's Blade",
-            "Info": "Choose One: Destroy a Bronze or Silver Cursed enemy; or deal 10 Damage.\nIf the unit was destroyed, Banish it.",
+            "Info": "Choose One: Destroy a Bronze or Silver Cursed enemy; or deal 10 Damage, If the unit was destroyed, Banish it.",
             "Flavor": "在阿德卡莱的一次骑士比武中，赛尔奇克打断了范德格里夫特的长剑。于是，愤怒的范德格里夫特下令铸造一把新的兵刃，还在上面附了强大的符文石。"
         },
         "44001": {
@@ -1943,7 +1943,7 @@
         },
         "44011": {
             "Name": "Siege Support",
-            "Info": "Whenever an ally appears, Boost it by 1. If it's a Machine, also give it 1 Armor.\nCrew.",
+            "Info": "Whenever an ally appears, Boost it by 1.\nIf it's a Machine, also give it 1 Armor.\nCrew.",
             "Flavor": "“你得把准星左校5度。”“把什么调多少？”"
         },
         "44012": {
@@ -1993,7 +1993,7 @@
         },
         "44021": {
             "Name": "Reaver Hunter",
-            "Info": "Deploy: Boost all copies of this unit by 1, if in hand, deck or on board. Repeat its ability whenever a copy of this unit is played.",
+            "Info": "Deploy: Boost all copies of this unit by 1, if in hand, deck or on the board.\nRepeat its ability whenever a copy of this unit is played.",
             "Flavor": "看见这纹身没？纹的是我在痛扁一条龙。一条龙哟，女士。"
         },
         "44022": {
@@ -2183,7 +2183,7 @@
         },
         "53005": {
             "Name": "Dennis Cranmer",
-            "Info": "Deploy: Strengthen all your other Dwarves in hand, deck and on board by 1.",
+            "Info": "Deploy: Strengthen all your other Dwarves in hand, deck and on the board by 1.",
             "Flavor": "我知道如何执行命令，冲别人去说教吧。"
         },
         "53006": {
@@ -2208,7 +2208,7 @@
         },
         "53010": {
             "Name": "Braenn",
-            "Info": "Deploy: Damage an enemy by this unit's power.\nIf the unit was destroyed, Boost all your other Dryads and Ambush units in hand, deck and on board by 1.",
+            "Info": "Deploy: Damage an enemy by this unit's power.\nIf the unit was destroyed, Boost all your other Dryads and Ambush units in hand, deck and on the board by 1.",
             "Flavor": "莫娜？不，不。我是布蕾恩。布洛克莱昂的女儿。"
         },
         "53011": {
@@ -2398,7 +2398,7 @@
         },
         "54027": {
             "Name": "Dol Blathanna Sentry",
-            "Info": "If in hand, deck or on board, Boost self by 1 whenever you play a special card.",
+            "Info": "If in hand, deck or on the board, Boost self by 1 whenever you play a special card.",
             "Flavor": "只要我们一息尚存，就绝不容许人类践踏多尔·布雷坦纳的绿荫。"
         },
         "54028": {
@@ -2673,7 +2673,7 @@
         },
         "64016": {
             "Name": "Tuirseach Veteran",
-            "Info": "Deploy: Strengthen all your other Clan Tuirseach units in hand, deck and on board by 1.",
+            "Info": "Deploy: Strengthen all your other Clan Tuirseach units in hand, deck and on the board by 1.",
             "Flavor": "我见人所未见，能人所不能。"
         },
         "64017": {
@@ -3048,12 +3048,12 @@
         },
         "70076": {
             "Name": "Congregation Cleric",
-            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base Strenght to 2.\nWhenever any Bronze unit is locked during your turn, generate a copy of it with 2 base Strength in the same row as this unit.",
+            "Info": "Deploy: Add on its row a 2 base Strenght copy of each Locked Bronze unit on the board.\nWhenever any Bronze unit is Locked during your turn, add a 2 base Strength copy of it in the same row as this unit.",
             "Flavor": "“靠近点，羔羊，再近点。愿永恒之火温暖你的灵魂！”"
         },
         "70077": {
             "Name": "Firesworn Zealot",
-            "Info": "Every 4 turns, at the end of the turn, deal 2 Damage to 4 random enemies.\nReduce the countdown by 1 for each locked unit on the board when played.",
+            "Info": "Every 4 turns, at the end of the turn, deal 2 Damage to 4 random enemies.\nReduce the first countdown by 1 for each Locked unit on the board when played.",
             "Flavor": "“我的信仰无人能敌，亦如我的怒火！”"
         },
         "70078": {
@@ -3068,7 +3068,7 @@
         },
         "70102": {
             "Name": "Detlaff: Crimson Curse",
-            "Info": "Deploy: Banish a Bronze Beast or Vampire unit from your graveyard, then Choose One: cast 3 rows of Full Moon on your side of the board; or cast 3 rows of Blood Moon on the opponent's side of the board.",
+            "Info": "Deploy: Banish a Bronze Beast or Vampire from your graveyard, then Choose One: Apply 3 rows of Full Moon; or apply 3 rows of Blood Moon.",
             "Flavor": ""
         },
         "70103": {
@@ -3078,7 +3078,7 @@
         },
         "70104": {
             "Name": "Lyrian Landsknecht",
-            "Info": "At the end of the round，if this card is Boosted，shuffle it back to the deck and keep at most 10 Boost.",
+            "Info": "At the end of the round, if this card is Boosted, shuffle it back to the deck and keep at most 10 Boost.",
             "Flavor": "“相信我，最好别去嘲笑他们傻里傻气的帽子。”"
         },
         "70105": {
@@ -3088,12 +3088,12 @@
         },
         "70106": {
             "Name": "Endrega Eggs",
-            "Info": "Deploy: Spawn 1 base copy of this card on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of your turn, destroy self.",
+            "Info": "Deploy: Spawn 1 base copy of this card on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of the turn, destroy self.",
             "Flavor": "If you find some it's best to burn the entire forest down. Then run as far away as you can."
         },
         "70107": {
             "Name": "Endrega Larva",
-            "Info": "After 3 turns, at the end of your turn, transform into Endrega Warrior.",
+            "Info": "After 3 turns, at the end of the turn, transform into Endrega Warrior.",
             "Flavor": "Fat, plump… and bloodthirsty."
         },
         "70108": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -2823,7 +2823,7 @@
         },
         "70001": {
             "Name": "Quen",
-            "Info": "Choose a Bronze or Silver unit in your hand, Boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any Damage once.",
+            "Info": "Choose a Bronze or Silver unit in your hand, then Boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any Damage once.",
             "Flavor": ""
         },
         "70002": {
@@ -2978,7 +2978,7 @@
         },
         "70041": {
             "Name": "Giga Scorpion Decoction",
-            "Info": "Damage the strongest enemy by 2\nRepeat 3 times.\nFor each White Raffard's Decoction in your graveyard, repeat once more.",
+            "Info": "Damage the strongest enemy by 2.\nRepeat 3 times.\nFor each White Raffard's Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70042": {
@@ -3033,7 +3033,7 @@
         },
         "70070": {
             "Name": "Highwaymen",
-            "Info": "Single-use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two copy of Strays of Spalla to your deck.",
+            "Info": "Single-use.\nIf there are only Bronze cards in your starting deck, Spawn a Strays of Spalla, then add two copies of Strays of Spalla to your deck.",
             "Flavor": "“商人？抹了。马匹？卖了。”"
         },
         "70071": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -2008,27 +2008,27 @@
         },
         "44024": {
             "Name": "Kaedweni Revenant",
-            "Info": "When you play your next Spell or Item, Spawn a Doomed default copy of this unit on its row. 1 Armor.",
+            "Info": "When you play your next Spell or Item, Spawn a doomed default copy of this unit on its row.\n1 Armor.",
             "Flavor": "万劫不复的士兵日复一日地过着同一天，就好像奇安凡尼银行的职员一样。"
         },
         "44025": {
             "Name": "Damned Sorceress",
-            "Info": "Deploy: If there is a Cursed unit on this unit's row, deal 7 damage. Increase the damage by 1 for each extra Cursed unit on the same row.",
+            "Info": "Deploy: If there is a Cursed unit on this unit's row, deal 7 damage.\nIncrease the damage by 1 for each extra Cursed unit on the same row.",
             "Flavor": "萨宾娜的诅咒谁也不放过，就连其他的女术士也难以幸免。"
         },
         "44026": {
             "Name": "Aretuza Adept",
-            "Info": "Deploy: Play a random Bronze Hazard card from your Deck.",
+            "Info": "Deploy: Play a random Bronze Hazard from your deck.",
             "Flavor": "这些女学员在艾瑞图萨活得像公主一样，任何怪诞的想法都能得到满足，同时半个城市都在服务于她们：裁缝、帽商、糖果商、贩夫走卒……"
         },
         "44027": {
             "Name": "Blue Stripe Commando",
-            "Info": "Whenever a different Temerian ally with the same power is played, Summon a copy of this unit from your deck.",
+            "Info": "Whenever a different Temerian ally with the same power is played, summon a copy of this unit from your deck.",
             "Flavor": "我愿为泰莫利亚赴汤蹈火，不过大多时候是在排除异己。"
         },
         "44028": {
             "Name": "Blue Stripe Scout",
-            "Info": "Deploy: Boost all Temerian allies and your non-Spying Temerian units in hand and deck with the same power as this unit by 1. Crew.",
+            "Info": "Deploy: Boost all Temerian allies and your non-Spying Temerian units in hand and deck with the same power as this unit by 1.\nCrew.",
             "Flavor": "蓝衣铁卫与松鼠党有个共通点——满心仇恨。"
         },
         "44029": {
@@ -2038,7 +2038,7 @@
         },
         "44030": {
             "Name": "Witch Hunter",
-            "Info": "Deploy: Reset a Unit. If it's a Mage, play another Witch Hunter from your Deck.",
+            "Info": "Deploy: Reset a unit.\nIf it's a Mage, play another Witch Hunter from your deck.",
             "Flavor": "女巫猎人都是些什么人？大部分都是流氓无赖、狂热分子。然而看到女术士集会所犯下的肮脏罪行，不少怒不可遏的体面人也加入了他们的行列……"
         },
         "44031": {
@@ -2053,7 +2053,7 @@
         },
         "44033": {
             "Name": "Winch",
-            "Info": "Choose One: Resurrect a Bronze Machine and add the Doomed category to it; or boost all machines on your side of the board by 3.",
+            "Info": "Choose One: Resurrect a Bronze Machine and add the doomed category to it; or boost all Machines on your side of the board by 3.",
             "Flavor": "就是一个绞盘。没什么可大惊小怪的。"
         },
         "44034": {
@@ -2083,12 +2083,12 @@
         },
         "51002": {
             "Name": "Eithné",
-            "Info": "Deploy: Resurrect a Bronze or Silver special card.",
+            "Info": "Deploy: Resurrect a Bronze or Silver Special card.",
             "Flavor": "树精女王眼似融银，心如冷钢。"
         },
         "51003": {
             "Name": "Filavandrel",
-            "Info": "Deploy: Create a Silver special card.",
+            "Info": "Deploy: Create a Silver Special card.",
             "Flavor": "虽然我们人数不多、四散分离，但我们的内心燃烧得比任何时候都要炽热。"
         },
         "51004": {
@@ -2103,7 +2103,7 @@
         },
         "52002": {
             "Name": "Saesenthessis",
-            "Info": "Deploy: Boost self by 1 for each Dwarf ally on the Board and in the Hand and deal 1 damage to an enemy for each Elf ally on the Board and in the Hand.",
+            "Info": "Deploy: Boost self by 1 for each Dwarf ally on the board and in your hand and deal 1 damage to an enemy for each Elf ally on the board and in your hand.",
             "Flavor": "我继承了父亲的变身能力……好吧，尽管我只有一种变化形态。"
         },
         "52003": {
@@ -2118,17 +2118,17 @@
         },
         "52005": {
             "Name": "Zoltan Chivay",
-            "Info": "Deploy: Choose 3 units. Strengthen allies by 2 and move them to this unit's row. Damage enemies by 2 and move them to the opposite row.",
+            "Info": "Deploy: Choose 3 units.\nStrengthen allies by 2 and move them to this unit's row.\nDamage enemies by 2 and move them to the opposite row.",
             "Flavor": "一人单独喝酒的滋味，就好比俩人一起蹲坑。"
         },
         "52006": {
             "Name": "Isengrim Faoiltiarna",
-            "Info": "Deploy: Play a Bronze or Silver Ambush from your Deck.",
+            "Info": "Deploy: Play a Bronze or Silver Ambush from your deck.",
             "Flavor": "他们一见我的疤就知道：这下死定了。"
         },
         "52007": {
             "Name": "Iorveth",
-            "Info": "Deploy: Deal 8 damage to an enemy. If the unit was destroyed, boost all Elves in your hand by 1.",
+            "Info": "Deploy: Deal 8 damage to an enemy.\nIf the unit was destroyed, boost all Elves in your hand by 1.",
             "Flavor": "国王还是乞丐于我并无差别，人类少一个算一个。"
         },
         "52008": {
@@ -2138,7 +2138,7 @@
         },
         "52009": {
             "Name": "Morenn: Forest Child",
-            "Info": "Ambush: When your opponent plays a Bronze or Silver special card, flip over and cancel its ability.",
+            "Info": "Ambush: When your opponent plays a Bronze or Silver Special card, flip over and cancel its ability.",
             "Flavor": "布洛克莱昂的意义远高于我的生命。她是一位母亲，关怀着自己的孩子们。我至死都要捍卫她。"
         },
         "52010": {
@@ -2153,17 +2153,17 @@
         },
         "52012": {
             "Name": "Iorveth: Meditation",
-            "Info": "Deploy: Force 2 enemies on the same row to Duel each other.",
+            "Info": "Deploy: Force 2 enemies on the same row to duel each other.",
             "Flavor": "即使伊欧菲斯只剩一只眼睛，他内心的洞察力也无人能及。"
         },
         "52013": {
             "Name": "Isengrim: Outlaw",
-            "Info": "Deploy, Choose One: Play a Bronze or Silver special card from your deck; or Create a Silver Elf.",
+            "Info": "Deploy, Choose One: Play a Bronze or Silver Special card from your deck; or Create a Silver Elf.",
             "Flavor": "在我们眼前的便是艾尔斯克德格山道，再往前，就是瑟瑞卡尼亚和哈克兰。这将是一条漫长而危险的道路。要想一同走下去，我们就得摒除彼此的猜忌。"
         },
         "53001": {
             "Name": "Yaevinn",
-            "Info": "Spying. Single-Use. Deploy: Draw a special card and a unit. Keep one and return the other to your deck.",
+            "Info": "Spying. Single-Use.\nDeploy: Draw a special card and a unit.\nKeep one and shuffle the other to your deck.",
             "Flavor": "我们是汇成风暴的雨滴。"
         },
         "53002": {
@@ -2183,7 +2183,7 @@
         },
         "53005": {
             "Name": "Dennis Cranmer",
-            "Info": "Deploy: Strengthen all your Dwarves by 1, wherever they are.",
+            "Info": "Deploy: Strengthen all your other Dwarves in hand, deck, and on board by 1.",
             "Flavor": "我知道如何执行命令，冲别人去说教吧。"
         },
         "53006": {
@@ -2193,27 +2193,27 @@
         },
         "53007": {
             "Name": "Yarpen Zigrin",
-            "Info": "Resilience. Whenever a Dwarf ally appears, boost self by 1.",
+            "Info": "Whenever a Dwarf ally appears, boost self by 1.\nResilience.",
             "Flavor": "听说过巨龙奥克维斯塔吗？石英山那只？亚尔潘·齐格林与他的矮人同伴们把它解决了。"
         },
         "53008": {
             "Name": "Malena",
-            "Info": "Ambush: After 2 turns, flip over and Charm the Highest Bronze or Silver enemy with 5 power or less.",
+            "Info": "Ambush: After 2 turns, on turn start, flip over and Charm the Highest Bronze or Silver enemy with 5 power or less.",
             "Flavor": "我恨你们，人类。你们全都一个样。"
         },
         "53009": {
             "Name": "Aelirenn",
-            "Info": "When 5 Elven allies are on the board, Summon this unit.",
+            "Info": "When 5 Elven allies are on the board, summon this unit.",
             "Flavor": "苟活不如好死。"
         },
         "53010": {
             "Name": "Braenn",
-            "Info": "Deploy: Deal damage equal to this unit's power. If a unit was destroyed, boost all your Dryad and Ambush units by 1, wherever they are.",
+            "Info": "Deploy: Deal damage equal to this unit's power to an enemy.\nIf a unit was destroyed, boost all your other Dryads and Ambush units in hand, deck, and on board by 1.",
             "Flavor": "莫娜？不，不。我是布蕾恩。布洛克莱昂的女儿。"
         },
         "53011": {
             "Name": "Toruviel",
-            "Info": "Ambush: When your opponent passes, turn this Unit over and Boost 2 Units on each side by 2.",
+            "Info": "Ambush: When your opponent passes, turn this unit over and boost 2 units on each side by 2.",
             "Flavor": "我很乐意站在你面前，直视你的双眼然后干掉你……但你臭死了，人类。"
         },
         "53012": {
@@ -2253,7 +2253,7 @@
         },
         "53019": {
             "Name": "Nature's Gift",
-            "Info": "Play a Bronze or Silver Special card from your Deck. Shuffle the others back.",
+            "Info": "Play a Bronze or Silver Special card from your deck.\nShuffle the others back.",
             "Flavor": "你们贪得无厌地榨干大地，野蛮强横地攫取它的财富。但在我们这儿，它生机勃勃，春华秋实，慷慨大方。因为它爱我们，正如我们爱它。"
         },
         "53020": {
@@ -2288,12 +2288,12 @@
         },
         "54005": {
             "Name": "Dwarven Mercenary",
-            "Info": "Deploy: Move a unit to this row on its side. If it's an ally, boost it by 3.",
+            "Info": "Deploy: Move a unit to this row on its side.\nIf it's an ally, boost it by 3.",
             "Flavor": "工作就该既有趣又赚钱——比如拿悬赏换金子。"
         },
         "54006": {
             "Name": "Farseer",
-            "Info": "If a different Ally or unit in your hand is Boosted during your turn, boost self by 2 at the end of the turn.",
+            "Info": "If a different ally or unit in your hand is boosted during your turn, boost self by 2 at the end of the turn.",
             "Flavor": "有时候，他的话语听似令人费解，但其中总是蕴藏着深邃的道理和惊人的智慧。"
         },
         "54007": {
@@ -2308,7 +2308,7 @@
         },
         "54009": {
             "Name": "Dol Blathanna Bowman",
-            "Info": "Deploy: Deal 2 damage to an enemy.\nWhenever an enemy moves, deal 2 damage to it. Whenever this unit moves, deal 2 damage to a random enemy.",
+            "Info": "Deploy: Deal 2 damage to an enemy.\nWhenever an enemy moves, deal 2 damage to it.\nWhenever this unit moves, deal 2 damage to a random enemy.",
             "Flavor": "也许你能躲过他们，但要被发现了，就别浪费时间逃跑了。"
         },
         "54010": {
@@ -2323,7 +2323,7 @@
         },
         "54012": {
             "Name": "Mahakam Marauder",
-            "Info": "Whenever this Unit is Boosted, Damaged, Strengthened or Weakened, Boost it by 2.",
+            "Info": "Whenever this unit is boosted, damaged, strengthened or weakened, boost it by 2.",
             "Flavor": "在玛哈坎崎岖的悬崖峭壁上狩猎可不是件简单事……但矮人们也从不轻易向危险低头。"
         },
         "54013": {
@@ -2338,7 +2338,7 @@
         },
         "54015": {
             "Name": "Dwarven Skirmisher",
-            "Info": "Deploy: Deal 3 damage to an enemy. If the unit was not destroyed, boost self by 3.",
+            "Info": "Deploy: Deal 3 damage to an enemy.\nIf the unit was not destroyed, boost self by 3.",
             "Flavor": "我跟十字镐打了一辈子交道，动动斧头算什么问题？"
         },
         "54016": {
@@ -2348,12 +2348,12 @@
         },
         "54017": {
             "Name": "Half-Elf Hunter",
-            "Info": "Deploy: Spawn a Doomed default copy of this unit.",
+            "Info": "Deploy: Spawn a doomed default copy of this unit.",
             "Flavor": "被人类痛恨，被精灵唾骂，而且学校操场上谁都不肯带他们玩。难怪半精灵一肚子委屈。"
         },
         "54018": {
             "Name": "Hawker Healer",
-            "Info": "Deploy: Boost 2 Allies by 3, and then Heal them.",
+            "Info": "Deploy: Boost 2 allies by 3, then heal them.",
             "Flavor": "帮你包扎，没问题——只要你有钱。"
         },
         "54019": {
@@ -2398,22 +2398,22 @@
         },
         "54027": {
             "Name": "Dol Blathanna Sentry",
-            "Info": "If in hand, deck or on board, boost self by 1 whenever you play a special card.",
+            "Info": "If in hand, deck or on board, boost self by 1 whenever you play a Special card.",
             "Flavor": "只要我们一息尚存，就绝不容许人类践踏多尔·布雷坦纳的绿荫。"
         },
         "54028": {
             "Name": "Sage",
-            "Info": "Deploy: Resurrect a Bronze Alchemy or Spell card, then Banish it.",
+            "Info": "Deploy: Resurrect a Bronze Alchemy or Spell card, then banish it.",
             "Flavor": "亲爱的，知识，乃是一种特权。而特权，只能被实力相当的人所分享。"
         },
         "54029": {
             "Name": "Dwarven Agitator",
-            "Info": "Deploy: Spawn a default copy of a random different Bronze Dwarf from your Deck.",
+            "Info": "Deploy: Spawn a default copy of a random different Bronze Dwarf from your deck.",
             "Flavor": "“记住我说的话，如果你们不行动起来，人类就会抢走我们的姑娘！”"
         },
         "54030": {
             "Name": "Elven Mercenary",
-            "Info": "Deploy: Look at 2 random Bronze special cards from your deck, then play 1.",
+            "Info": "Deploy: Look at 2 random Bronze Special cards from your deck, then play 1.",
             "Flavor": "我瞧不起松鼠党，但不讨厌他们的钱。"
         },
         "54031": {
@@ -2433,7 +2433,7 @@
         },
         "62001": {
             "Name": "Olaf",
-            "Info": "Deploy: Deal 10 damage to self. Reduce the damage inflicted by 2 for each Beast you played this match.",
+            "Info": "Deploy: Deal 10 damage to self.\nReduce the damage inflicted by 2 for each Beast you played this match.",
             "Flavor": "备受敬仰的小史凯利格岛竞技场十冠王。"
         },
         "62002": {
@@ -2443,7 +2443,7 @@
         },
         "62003": {
             "Name": "Vabjorn",
-            "Info": "Deploy: Deal 2 damage. If the unit was already damaged , destroy it instead.",
+            "Info": "Deploy: Deal 2 damage.\nIf the unit was already damaged, destroy it instead.",
             "Flavor": "为了斯瓦勃洛！"
         },
         "62004": {
@@ -2453,7 +2453,7 @@
         },
         "62005": {
             "Name": "Wild Boar of the Sea",
-            "Info": "On turn end, Strengthen the unit to the left by 1, then deal 1 damage to the unit to the right. 5 Armor.",
+            "Info": "On turn end, strengthen the unit to the left by 1, then deal 1 damage to the unit to the right.\n5 Armor.",
             "Flavor": "只消对尼弗迦德人提起这个名字，他们就会吓得尿裤子……"
         },
         "62006": {
@@ -2463,22 +2463,22 @@
         },
         "62007": {
             "Name": "Cerys an Craite",
-            "Info": "When 4 units are Resurrected while this unit is in the graveyard, Resurrect it and gain 1 strength",
+            "Info": "When 4 units are resurrected while this unit is in the graveyard, resurrect it and strenghten it by 1.",
             "Flavor": "大家叫我小雀鹰，知道为什么吗？因为我专治你这种鼠辈。"
         },
         "62008": {
             "Name": "Madman Lugos",
-            "Info": "Deploy: Discard a Bronze Unit from your Deck and Damage a Unit by the Discarded Unit's base Power.",
+            "Info": "Deploy: Discard a Bronze unit from your deck and damage a unit by the Discarded unit's base power.",
             "Flavor": "哇哇哇哇哇哇啊！！！！"
         },
         "62009": {
             "Name": "Ulfhedinn",
-            "Info": "Deploy: Deal 1 damage to all enemies. If the enemies were damaged, deal 2 damage instead.",
+            "Info": "Deploy: Deal 1 damage to all enemies.\nIf the enemies were damaged, deal 2 damage instead.",
             "Flavor": "狼人？哦，不，不……比那要糟糕得多。"
         },
         "62010": {
             "Name": "Cerys: Fearless",
-            "Info": "Resurrect the next unit your Discard.",
+            "Info": "Resurrect the next unit you discard.",
             "Flavor": "我必须要团结各大家族。我希望能够避免开战。但假如尼弗迦德执意来犯，那我们就一定要同仇敌忾。"
         },
         "62011": {
@@ -2493,7 +2493,7 @@
         },
         "62013": {
             "Name": "Kambi",
-            "Info": "Spying. Deathwish: Spawn Hemdall.",
+            "Info": "Spying.\nDeathwish: Spawn Hemdall.",
             "Flavor": "终焉之刻来临时，金公鸡坎比便会叫醒沉睡的汉姆多尔。"
         },
         "63001": {
@@ -2503,12 +2503,12 @@
         },
         "63002": {
             "Name": "Udalryk",
-            "Info": "Spying. Single-Use. Deploy: Look at 2 cards from your deck. Draw one and Discard the other.",
+            "Info": "Spying. Single-Use.\nDeploy: Look at 2 cards from your deck.\nDraw one and discard the other.",
             "Flavor": "诸神已经发话，必须献上祭品。"
         },
         "63003": {
             "Name": "Djenge Frett",
-            "Info": "Deploy: Deal 1 damage to 2 allies and Strengthen self by 2 for each.",
+            "Info": "Deploy: Deal 1 damage to 2 allies and strengthen self by 2 for each.",
             "Flavor": "如果通缉令上写着“无论死活”，绝大多数赏金猎人会直接快刀斩乱麻。但我不会。如果被我抓到，我会把人吊起来挠痒，让他笑到岔气。"
         },
         "63004": {
@@ -2518,12 +2518,12 @@
         },
         "63005": {
             "Name": "Morkvarg",
-            "Info": "Whenever this unit enter the graveyard, Resurrect it and Weaken it by half.",
+            "Info": "Whenever this unit enter the graveyard, resurrect it and weaken it by half.",
             "Flavor": "史凯利格有史以来最大的恶人。"
         },
         "63006": {
             "Name": "Svanrige Tuirseach",
-            "Info": "Deploy: Draw a card, then Discard a card.",
+            "Info": "Deploy: Draw a card, then discard a card.",
             "Flavor": "皇帝最开始也认为自己登上皇位是出于偶然。"
         },
         "63007": {
@@ -2548,7 +2548,7 @@
         },
         "63011": {
             "Name": "Holger Blackhand",
-            "Info": "Deploy: Deal 7 damage. If the unit was destroyed, Strengthen the Highest unit in your graveyard by 3.",
+            "Info": "Deploy: Deal 7 damage.\nIf the unit was destroyed, strengthen the Highest unit in your graveyard by 3.",
             "Flavor": "敬尼弗迦德皇帝，祝他不得善终！"
         },
         "63012": {
@@ -2558,7 +2558,7 @@
         },
         "63013": {
             "Name": "Yoana",
-            "Info": "Deploy: Heal an ally, then boost it by the amount Healed.",
+            "Info": "Deploy: Heal an ally, then boost it by the amount healed.",
             "Flavor": "没人会把我当成一名老练的盔甲师傅。只是一个人类，而且还是个女人。可是矮人铁匠就不同了……"
         },
         "63014": {
@@ -2568,7 +2568,7 @@
         },
         "63015": {
             "Name": "Skjall",
-            "Info": "Deploy: Play a random Bronze or Silver Cursed Unit from your Deck.",
+            "Info": "Deploy: Play a random Bronze or Silver Cursed unit from your deck.",
             "Flavor": "把他剔出族谱！不许任何人给他食物和庇护！"
         },
         "63016": {
@@ -2588,12 +2588,12 @@
         },
         "63019": {
             "Name": "Restore",
-            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the Doomed category to it, and set its base power to 8. Then play a card.",
+            "Info": "Return a Bronze or Silver Skellige unit from your graveyard to your hand, add the doomed category to it, and set its base power to 8.\nThen play a card.",
             "Flavor": "那些该死的女术士又抢咱们的风头！只要几个年轻姑娘挥挥手就能解决的话，谁还选择这么费时费力的办法？"
         },
         "63020": {
             "Name": "Ornamental Sword",
-            "Info": "Create a Bronze or Silver Skellige Soldier and Strengthen it by 3.",
+            "Info": "Create a Bronze or Silver Skellige Soldier and strengthen it by 3.",
             "Flavor": "看上去很精美，但顶多也就只能用来抹抹黄油。"
         },
         "64001": {
@@ -2638,7 +2638,7 @@
         },
         "64009": {
             "Name": "An Craite Greatsword",
-            "Info": "Every 2 turns, if damaged, on turn start, Heal self and Strengthen by 2.",
+            "Info": "Every 2 turns, on turn start, if damaged, heal self and strengthen by 2.",
             "Flavor": "啊哈哈，你真让我笑掉大牙，北方佬！怎么？我手上这把大家伙，你都不一定拿得动，还想用它对付我？"
         },
         "64010": {
@@ -2653,12 +2653,12 @@
         },
         "64012": {
             "Name": "Tuirseach Skirmisher",
-            "Info": "Whenever this unit is Resurrected, Strengthen it by 4.",
+            "Info": "Whenever this unit is resurrected, strengthen it by 4.",
             "Flavor": "记好了：我们对朋友掏心窝，对敌人挥斧子。"
         },
         "64013": {
             "Name": "Svalblod Ravager",
-            "Info": "Whenever this unit is damaged or Weakened, transform into a Raging Bear.",
+            "Info": "Whenever this unit is damaged or weakened, transform into a Raging Bear.",
             "Flavor": "在诗人的歌谣里，鏖战中变身的狂战士跟野熊没两样。"
         },
         "64014": {
@@ -2683,7 +2683,7 @@
         },
         "64018": {
             "Name": "An Craite Longship",
-            "Info": "Deploy: Deal 2 damage to a random enemy. Repeat this ability whenever you Discard a card.",
+            "Info": "Deploy: Deal 2 damage to a random enemy.\nRepeat this ability whenever you discard a card.",
             "Flavor": "据说只要有长船出海劫掠，汉姆多尔就会心潮澎湃。"
         },
         "64019": {
@@ -2693,7 +2693,7 @@
         },
         "64020": {
             "Name": "An Craite Marauder",
-            "Info": "Deploy: Deal 4 damage. If Resurrected, deal 6 damage instead.",
+            "Info": "Deploy: Deal 4 damage.\nIf resurrected, deal 6 damage instead.",
             "Flavor": "你疯了不成？你想去史凯利格？哪些野蛮人会让你吃大苦头的！"
         },
         "64021": {
@@ -2703,7 +2703,7 @@
         },
         "64022": {
             "Name": "Tuirseach Axeman",
-            "Info": "Whenever an enemy on the opposite row is damaged, boost self by 1. 2 Armor.",
+            "Info": "Whenever an enemy on the opposite row is damaged, boost self by 1.\n2 Armor.",
             "Flavor": "小姑娘才用剑，弄把斧头吧。"
         },
         "64023": {
@@ -2713,7 +2713,7 @@
         },
         "64024": {
             "Name": "An Craite Raider",
-            "Info": "Whenever you Discard this unit, Resurrect it.",
+            "Info": "Whenever you discard this unit, resurrect it.",
             "Flavor": "我们可是奎特家族！別人用金子购买，我们拿血汗交换。"
         },
         "64025": {
@@ -2758,12 +2758,12 @@
         },
         "64033": {
             "Name": "Tuirseach Bearmaster",
-            "Info": "Deploy: Spawn a Bear.",
+            "Info": "Deploy: Spawn an Elder Bear.",
             "Flavor": "别碰他。别盯着他的眼睛瞧。事实上……压根就别靠近他。"
         },
         "64034": {
             "Name": "Bone Talisman",
-            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or Heal an ally and Strengthen it by 3.",
+            "Info": "Choose One: Resurrect a Bronze Beast or Cultist unit or heal an ally and strengthen it by 3.",
             "Flavor": "有时最普通不过的物件却拥有最为强大的威力。"
         },
         "65001": {
@@ -2778,17 +2778,17 @@
         },
         "65003": {
             "Name": "Lord of Undvik",
-            "Info": "Spying. Deathwish: Boost enemy Hjalmars by 10.",
+            "Info": "Spying.\nDeathwish: Boost enemy Hjalmars by 10.",
             "Flavor": "这个怪物将名门世族托达洛克家族的故乡——乌德维克岛变成了荒凉之地，昔日荣光一去不返……"
         },
         "65004": {
             "Name": "Spectral Whale",
-            "Info": "Spying. On turn end, move to a random row and deal 1 damage to all units on it. Deathwish: invoke this ability again.",
+            "Info": "Spying.\nOn turn end, move to a random row and deal 1 damage to all units on it.",
             "Flavor": "“呃，座头鲸应该没那么大。那是头长须鲸。”“嘴那么短的长须鲸？你被药草冲昏了头吗！”"
         },
         "65005": {
             "Name": "Wilfred",
-            "Info": "Deathwish: Strengthen a random Ally by 3.",
+            "Info": "Deathwish: Strengthen a random ally by 3.",
             "Flavor": "高个子的是威尔玛。他右边的是威尔弗雷德。结巴的那个是威尔海姆。"
         },
         "65006": {
@@ -2818,22 +2818,22 @@
         },
         "61004": {
             "Name": "Bran Tuirseach",
-            "Info": "Deploy: Discard up to 3 cards from your deck and Strengthen them by 1.",
+            "Info": "Deploy: Discard up to 3 cards from your deck and strengthen them by 1.",
             "Flavor": "没人能取代布兰王，但后世定会努力尝试。"
         },
         "70001": {
             "Name": "Quen",
-            "Info": "Choose a Bronze or Silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them shield. The shield can block any damage once.",
+            "Info": "Choose a Bronze or Silver unit in your hand, boost it and all its copies in your hand and deck by 2 and give them Shield. The Shield can block any damage once.",
             "Flavor": ""
         },
         "70002": {
             "Name": "Detlaff: Higher Vampire",
-            "Info": "Deploy, Choose one: Play a Bronze unit from your deck with power equal to or less than this unit's. Send it to the graveyard at the end of the turn; or Consume a bronze unit from your deck with more power than this unit and gain its power.",
+            "Info": "Deploy, Choose one: Play a Bronze unit from your deck with power equal to or less than this unit's, then send that unit to the graveyard at the end of the turn; or consume a bronze unit from your deck with more power than this unit and gain its power.",
             "Flavor": ""
         },
         "70003": {
             "Name": "Hammond",
-            "Info": "Deploy, Choose one: Spawn a Skellige Bronze Machine unit; or Boost all friendly machines on the board by 2.\nUnits in this row are immune to damage from hazards.",
+            "Info": "Deploy, Choose one: Spawn a Skellige Bronze Machine; or boost all friendly Machines on the board by 2.\nUnits in this row are immune to damage from Hazards.",
             "Flavor": ""
         },
         "70004": {
@@ -2843,7 +2843,7 @@
         },
         "70005": {
             "Name": "Vysogota Of Corvo",
-            "Info": "On round start, boost a unit to the left by 3, damage self by 1 and move to a row with the least number of units.\nDeathwish: Boost the weakest friendly unit by 6.",
+            "Info": "On round start, boost a unit to the left by 3, then damage self by 1 and move to the row with the least amount of units.\nDeathwish: Boost the Lowest ally by 6.",
             "Flavor": ""
         },
         "70006": {
@@ -2853,7 +2853,7 @@
         },
         "70007": {
             "Name": "Prophet Lebioda",
-            "Info": "When banished, boost all friendly units by 1.",
+            "Info": "When banished, boost all allies by 1.",
             "Flavor": ""
         },
         "70008": {
@@ -2903,7 +2903,7 @@
         },
         "70017": {
             "Name": "Cintrian Field Medic",
-            "Info": "Deploy: Shuffle a non-identical friendly Bronze unit back to the deck, and then play a random Bronze unit from the deck.",
+            "Info": "Deploy: Shuffle a non-identical Bronze ally back to your deck, then play a random Bronze unit from your deck.",
             "Flavor": ""
         },
         "70019": {
@@ -2923,12 +2923,12 @@
         },
         "70022": {
             "Name": "Kikimore Worker",
-            "Info": "Deploy: Choose an Insectoid friendly unit, and boost all the cards with the same name on your side of the board, hand and deck by 2 points.",
+            "Info": "Deploy: Choose an Insectoid ally, then boost all the cards with the same name on your side of the board, hand and deck by 2 points.",
             "Flavor": ""
         },
         "70023": {
             "Name": "Kikimore Warrior",
-            "Info": "Deploy: Consume a non-identical Bronze unit in your own deck with current power no greater than its own, then boost self by its power.",
+            "Info": "Deploy: Consume a non-identical Bronze unit in your deck with current power no greater than its own, then boost self by its power.",
             "Flavor": ""
         },
         "70024": {
@@ -2938,12 +2938,12 @@
         },
         "70025": {
             "Name": "Syanna",
-            "Info": "Single-use. Repeat the Deploy ability of the next Bronze or Silver loyal unit you play. 4 Armor.",
+            "Info": "Single-use.\nRepeat the Deploy ability of the next Bronze or Silver loyal unit you play.\n4 Armor.",
             "Flavor": "Your Majesty... The princess has been touched by the curse o' the Black Sun. There's no hope, I'm afraid..."
         },
         "70026": {
             "Name": "Ivo of Belhaven",
-            "Info": "On round start, if you have more points than the opponent, strengthen self by 2 points.\nDeathwish: Move a random demon hunter in your deck to the top of your deck.",
+            "Info": "On round start, if you have more points than the opponent, strengthen self by 2 points.\nDeathwish: Move a random Bronze or Silver Witcher in your deck to the top of your deck.",
             "Flavor": ""
         },
         "70027": {
@@ -2958,7 +2958,7 @@
         },
         "70033": {
             "Name": "War Elephant",
-            "Info": "Deploy: Destroy the armor of all units in this row and damage a unit by the amount destroyed.",
+            "Info": "Deploy: Destroy the Armor of all units on a row on your side of the board, then damage a unit by the amount destroyed.",
             "Flavor": ""
         },
         "70038": {
@@ -2968,22 +2968,22 @@
         },
         "70039": {
             "Name": "Dire Wolf Claws",
-            "Info": "Deploy: Deal 4 damage to a random enemy unit. When discarded, trigger this ability and shuffle 2 Dire Wolf Warriors in your deck.",
+            "Info": "Deal 4 damage to a random enemy.\nWhen discarded, trigger its ability and add 2 copies of Dire Wolf Warrior in your deck.",
             "Flavor": ""
         },
         "70040": {
             "Name": "Dire Wolf Warrior",
-            "Info": "Deploy: Deal 2 damage to a random enemy unit. When discarded, trigger this ability and shuffle a copy of this card to the bottom of your deck.",
+            "Info": "Deploy: Deal 2 damage to a random enemy.\nWhen discarded, trigger its ability and add a copy of this card to the bottom of your deck.",
             "Flavor": ""
         },
         "70041": {
             "Name": "Giga Scorpion Decoction",
-            "Info": "Damage the strongest enemy unit by 2 points. Repeat 3 times. For each White Raffard's Decoction in your graveyard, repeat once more.",
+            "Info": "Damage the strongest enemy by 2. Repeat 3 times. For each White Raffard's Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70042": {
             "Name": "White Raffard's Decoction",
-            "Info": "Boost the weakest ally unit by 2 points. Repeat 3 times. For each Giga Scorpion Decoction in your graveyard, repeat once more.",
+            "Info": "Boost the weakest ally by 2. Repeat 3 times. For each Giga Scorpion Decoction in your graveyard, repeat once more.",
             "Flavor": ""
         },
         "70043": {
@@ -2993,17 +2993,17 @@
         },
         "70044": {
             "Name": "Vernossiel",
-            "Info": "Deploy: Add 2 Vernossiel's Commandos to your deck and reduce their counter by 1.",
+            "Info": "Deploy: Add 2 copies of Vernossiel's Commando to your deck and reduce their counter by 1.",
             "Flavor": ""
         },
         "70045": {
             "Name": "Meve",
-            "Info": "Deploy: Boost a unit on your side of the board, in your hand and in your deck each by 4. Crew.",
+            "Info": "Deploy: Boost a unit on your side of the board, in your hand and in your deck each by 4.\nCrew.",
             "Flavor": ""
         },
         "70046": {
             "Name": "Svalblod Fanatic",
-            "Info": "On round end, deal 3 damage to the weakest enemy unit, then deal 3 damage to self.",
+            "Info": "On round end, deal 3 damage to the Lowest enemy, then deal 3 damage to self.",
             "Flavor": ""
         },
         "70050": {
@@ -3013,47 +3013,47 @@
         },
         "70054": {
             "Name": "Feign Death",
-            "Info": "Resurrect 2 Bronze units with power higher than 5 points, then deal 4 damage to each of them.",
+            "Info": "Resurrect 2 Bronze units with power higher than 5, then deal 4 damage to each of them.",
             "Flavor": ""
         },
         "70058": {
             "Name": "Cave Troll",
-            "Info": "Deploy: Boost self by 4, then boost an enemy by 4 points.",
+            "Info": "Deploy: Boost self by 4, then boost an enemy by 4.",
             "Flavor": ""
         },
         "70059": {
             "Name": "One-Eyed Betsy",
-            "Info": "At the beginning of the round, boost self by 3 points, then boost the strongest enemy by 3 points.",
+            "Info": "At the beginning of the round, boost self by 3, then boost the Highest enemy by 3.",
             "Flavor": "准头是差了点，但力道确实没话说。"
         },
         "70062": {
             "Name": "Living Armor",
-            "Info": "Units in the same row take at most 5 points of damage.",
+            "Info": "Units in the same row as this unit take at most 5 damage at once.",
             "Flavor": "价钱是贵了点。但是你把节省下来的吃住都算进去，不出一百年就能回本！"
         },
         "70070": {
             "Name": "Highwaymen",
-            "Info": "Single-use. If there are only Bronze cards in your starting deck, spawn a Strays of Spalla, then add two Strays of Spalla to your deck.",
+            "Info": "Single-use.\nIf there are only Bronze cards in your starting deck, spawn a Strays of Spalla, then add two copy of Strays of Spalla to your deck.",
             "Flavor": "“商人？抹了。马匹？卖了。”"
         },
         "70071": {
-            "Name": "StraysofSpalla",
-            "Info": "Single-use. Look at 2 random Bronze units in your deck, then play one.",
+            "Name": "Strays Of Spalla",
+            "Info": "Single-use.\nLook at 2 random Bronze units in your deck, then play one.",
             "Flavor": "“嗷，嗷，嗷嗷！”"
         },
         "70072": {
             "Name": "Radeyah",
-            "Info": "Deal damage equal to the number of neutral cards in your hand.",
+            "Info": "Deploy: Deal damage equal to the number of neutral cards in your hand.",
             "Flavor": "“迷人的微笑背后可以潜藏许多秘密……”"
         },
         "70076": {
             "Name": "Congregation Cleric",
-            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base strenght to 2. Whenever any Bronze unit is locked during your turn, generate a copy of it with 2 base strength in the same row.",
+            "Info": "Deploy: Generate copies of all locked Bronze units, then set their base strenght to 2. Whenever any Bronze unit is locked during your turn, generate a copy of it with 2 base strength in the same row as this unit.",
             "Flavor": "“靠近点，羔羊，再近点。愿永恒之火温暖你的灵魂！”"
         },
         "70077": {
             "Name": "Firesworn Zealot",
-            "Info": "Every 4 turns, deal 2 damage to 4 random enemies at the end of the turn. Reduce the countdown by 1 for each locked unit on the board when played.",
+            "Info": "Every 4 turns, at the end of the turn, deal 2 damage to 4 random enemies. Reduce the countdown by 1 for each locked unit on the board when played.",
             "Flavor": "“我的信仰无人能敌，亦如我的怒火！”"
         },
         "70078": {
@@ -3063,7 +3063,7 @@
         },
         "70091": {
             "Name": "Magic Lamp",
-            "Info": "At the start of the game, add 3 The Last Wish to your deck, then Discard self.",
+            "Info": "At the start of the game, add 3 copies of The Last Wish to your deck, then discard self.",
             "Flavor": "破译梦境中的过去和未来是非常困难的，即使对大师也是如此。"
         },
         "70102": {
@@ -3088,7 +3088,7 @@
         },
         "70106": {
             "Name": "Endrega Eggs",
-            "Info": "Deploy: Spawn 1 base copy on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of your turn, destroy self.",
+            "Info": "Deploy: Spawn 1 base copy of this card on the left.\nDeathwish: Spawn an Endrega Larva in this row.\nAfter 3 turns, at the end of your turn, destroy self.",
             "Flavor": "If you find some it's best to burn the entire forest down. Then run as far away as you can."
         },
         "70107": {
@@ -3103,17 +3103,17 @@
         },
         "70109": {
             "Name": "Dwarven Chariot",
-            "Info": "Select 2 units and move them to this unit's row. When this unit is moved, boost a random unit in the same row by 2.",
+            "Info": "Choose 2 units and move them to this unit's row. When this unit is moved, boost a random unit in the same row as this unit by 2.",
             "Flavor": "“随你们怎么画，各位亲爱的矮人。但是我把话放在这里，它造不出来。”"
         },
         "130210": {
             "Name": "Dudu: Promoted",
-            "Info": "Choose an Enemy and become its copy.",
+            "Info": "Choose an enemy and become its copy.",
             "Flavor": "拟态怪有很多别名：易形怪、二重身、模仿怪……变形怪。"
         },
         "130220": {
             "Name": "Prize-Winning Cow: Promoted",
-            "Info": "Deathwish: Spawn a 'Chort'，and then deal 2 damage to all emenies on the same row",
+            "Info": "Deathwish: Spawn a Chort，and then deal 2 damage to all emenies on the same row",
             "Flavor": "哞～～～"
         },
         "130200": {
@@ -3123,17 +3123,17 @@
         },
         "130180": {
             "Name": "Vaedermakar: Promoted",
-            "Info": "Deploy: Spawn a Netural brown/sliver hazard, Clear Skies, or Alzur's Thunder",
+            "Info": "Deploy: Spawn a Neutral Bronze or Silver Hazard, Clear Skies, or Alzur's Thunder",
             "Flavor": "控天者德鲁伊能操控各种元素之力，让狂风暴雨化为绕指柔风，降下毁天灭地的雹暴，还能拖雷掣电让敌军灰飞烟灭……所以我给你个忠告：面对他，一定要毕恭毕敬。"
         },
         "130190": {
             "Name": "Iris von Everec: Promoted",
-            "Info": "Spying. Deathwish: Boost 6 random units on the opposite side by 5.",
+            "Info": "Spying.\nDeathwish: Boost 6 random units on the opposite side by 5.",
             "Flavor": "我的回忆所剩无几……但每次想到我的玫瑰，记忆便会涌现。"
         },
         "130010": {
             "Name": "Roach: Promoted",
-            "Info": "Whenever you play a Gold unit from your hand, Summon this unit. If it is in your hand, summon it and draw one card. If it is in your graveyard, return to your deck.",
+            "Info": "Whenever you play a Gold unit from your hand, summon this unit.\nIf it is in your hand, summon it and draw one card.\nIf it is in your graveyard, return to your deck.",
             "Flavor": "杰洛特，我们得来场人马间的对话。恕我直言，你的骑术……真的有待提高，伙计。"
         },
         "130150": {
@@ -3143,32 +3143,32 @@
         },
         "130020": {
             "Name": "Francis Bedlam: Promoted",
-            "Info": "Deploy: If losing, Strengthen self up to a maximum of 20 until you outweight 1 scores",
+            "Info": "Deploy: If losing, strengthen self up to a maximum of 20 until you outweight 1 scores",
             "Flavor": "要是我缺鼻子或者断手了，那显然，乞丐王接受这两种付款方式。"
         },
         "130160": {
             "Name": "Operator: Promoted",
-            "Info": "Exhausted. Deploy, Truce: Make a default copy of a non-exhausted Bronze/Sliver unit in your hand for both players.",
+            "Info": "Single-Use\nDeploy, Truce: Make a default copy of a non-Single-Use Bronze or Silver unit in your hand for both players.",
             "Flavor": "时空在我们面前瓦解，也在我们身后膨胀，这就是穿越。"
         },
         "130130": {
             "Name": "Vesemir: Promoted",
-            "Info": "Deploy: Summon Eskel and Lambert, and promote them.",
+            "Info": "Deploy: Summon Eskel and Lambert, then promote them.",
             "Flavor": "就算上了绞架也别放弃——让他们给你拿点水，毕竟没人知道水拿来前会发生什么。"
         },
         "130140": {
             "Name": "Eskel: Promoted",
-            "Info": "Deploy: Summon Vesemir and Lambert, and promote them.",
+            "Info": "Deploy: Summon Vesemir and Lambert, then promote them.",
             "Flavor": "白狼，我只是个普通猎魔人。我不猎龙，不跟国王称兄道弟，也不和女术士纠缠……"
         },
         "130170": {
             "Name": "Lambert: Promoted",
-            "Info": "Deploy: Summon Eskel and Vesemir, and promote them.",
+            "Info": "Deploy: Summon Eskel and Vesemir, then promote them.",
             "Flavor": "这样的沟通方式才对路嘛！"
         },
         "130110": {
             "Name": "Carlo Varese",
-            "Info": "Deal 9 damage. Deal overfolw damge to neighbors.",
+            "Info": "Deal 9 damage.\nDeal overflowed damge to adjacent cards.",
             "Flavor": "每个想要在诺维格瑞做生意的都很清楚——要么同意卡罗的条件，要么就夹着尾巴滚出去。"
         },
         "130090": {
@@ -3178,17 +3178,17 @@
         },
         "130100": {
             "Name": "Ocvist: Promoted",
-            "Info": "Exhaust. After 3 turns, deal 1 damage to all enemies, then on round start, return to your hand.",
+            "Info": "Single-Use.\nAfter 3 turns, deal 1 damage to all enemies, then on round start, return to your hand.",
             "Flavor": "他是石英山之主，毁灭者，图拉真的屠夫。但在闲暇时间里，他喜欢远足和烛光晚餐。"
         },
         "130120": {
             "Name": "Myrgtabrakke: Promoted",
-            "Info": "Deploy: Damage Units by 4, 3, 2 and then 1.",
+            "Info": "Deploy: Damage units by 4, 3, 2 and then 1.",
             "Flavor": "永远别想分开母龙和她的孩子。"
         },
         "130080": {
             "Name": "Johnny: Promoted",
-            "Info": "Deploy: Discard a card. Then create a copy of a card of the same color from your opponent's starting deck in your hand.",
+            "Info": "Deploy: Discard a card, then create a copy of a card of the same color from your opponent's starting deck in your hand.",
             "Flavor": "要是再也没办法亲口说出“狮子头上长虱子”，生活就真的太无趣啦。"
         },
         "130050": {
@@ -3203,7 +3203,7 @@
         },
         "130070": {
             "Name": "Stregobor: Promoted",
-            "Info": "Deploy, Truce: Check two unit card in opponent's deck, and place one on top of the deck. Each player draws a unit and sets its power to 1.",
+            "Info": "Deploy, Truce: Check two unit card in the opponent's deck, and place one on top of the deck.\nEach player draws a unit and sets its power to 1.",
             "Flavor": "猎魔人见过看上去像议员的贼，见过看上去像乞丐的议员，也见过看上去像贼的国王。不过斯崔葛布的样子，就和大众心目中法师的形象没什么两样。"
         },
         "130030": {
@@ -3213,7 +3213,7 @@
         },
         "130040": {
             "Name": "Iris' Companions: Promoted",
-            "Info": "Discard a random card, and move a card from your deck to your hand.",
+            "Info": "Discard a random card, then move a card from your deck to your hand.",
             "Flavor": "我们的名字还是不说为好。就当我们是……主人家的朋友吧。"
         },
         "640080": {
@@ -3223,7 +3223,7 @@
         },
         "240140": {
             "Name": "Drowner: Promoted",
-            "Info": "Deploy: Move 2 enemies to the opposite row and deal 2 damage to it. If that row is under a Hazard, deal 4 damage instead.",
+            "Info": "Deploy: Move 2 enemies to the opposite row and deal 2 damage to it.\nIf that row is under a Hazard, deal 4 damage instead.",
             "Flavor": "尽管猎魔人想多赚些金币，但杀水鬼这活儿只值一枚银币，或者三个铜板——不能再多了。"
         },
         "240230": {
@@ -3233,7 +3233,7 @@
         },
         "240250": {
             "Name": "Barbegazi: Promoted",
-            "Info": "Consume an ally and boost self by its power. Resilient.",
+            "Info": "Consume an ally and boost self by its power.\nResilient.",
             "Flavor": "岩洞中先前还和石头没什么两样的怪物，倏地瞪大眼睛，充满恶意地盯着他。"
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -2333,7 +2333,7 @@
         },
         "54014": {
             "Name": "Dol Blathanna Bomber",
-            "Info": "Deploy: Spawn an Incinerating Trap on an enemy row.\n(Damage all units on this row by 2 on turn end)",
+            "Info": "Deploy: Spawn an Incinerating Trap on an enemy row.\n(Incinerating Trap; 1 Strength; Damage all units on this row by 2 on turn end)",
             "Flavor": "他们的追踪本领犹如猎犬，双腿健似矫鹿，残忍更胜恶魔。"
         },
         "54015": {
@@ -2858,7 +2858,7 @@
         },
         "70008": {
             "Name": "Vivienne: Oriole",
-            "Info": "On turn end, if your total Power exceeds the opponent's Power by 25 points or more, return to your hand.",
+            "Info": "Single-Use.\nOn turn end, if your total Power exceeds the opponent's Power by 25 points or more, return to your hand.",
             "Flavor": ""
         },
         "70009": {


### PR DESCRIPTION
Adding capitalization to all Keywords: (ex. Bronze, Machine, Damage etc...)
Following cards name changed: LyrianLandsknecht->Lyrian Landsknecht, Detlaff: CrimsonCurse->Detlaff: Crimson Curse, Treason->Assassination(Gold card. This is the correct Beta name, and there is already a Silver card with the name Treason), 25005->Harpy Hatchling(This card didn't have a name), Arachas Drone->Arachas Hatchling(There are two cards with the same name, both Drone,  the card that is getting changed to the correct name is the Token card spawned from Arachas Behemoth. The card you can put in the deck is still Arachas Drone).
Added missing specification to a few cards, when timed cards trigger the effect. Now they correctly specify if they trigger at the end or beginning of the turn.
Added description to spawned cards that are not viewable in the deck editor: (ex. Kambi now has also Hemdall description, Blueboy Lugos now has also Spectral Whale description etc...).
Various typo fixes: (ex. Sliver->Silver, Emeny->Enemy etc...)
Better translation and fixes to multiple cards, being more consistent with wording, removing certain words that only appeared on 1 or 2 cards (mainly DIY cards) to have better similarity to the vast majority of current cards: (Ex. Friendly unit->Ally etc...).
Wrong effects on certain descriptions fixed: (ex. One-Eyed Betsy: Beginning of round->Beginning of turn etc...).
Sentences are separated now, and certain keywords (Armor, Immune, Resilience etc...) Are put alone at the begining or end of the description (Ex. If you want to check if a unit deploys with armor, the amount of armor it deploys with is always shown at the end of the description).

What is NOT fixed is the following:
Some cards still doesn't specify with correct wording (ex. "May Reveal", instead of just "Reveal", "May play" instead of just "Play") if you are forced to play another card from the deck etc... But it can be something for a future update on descriptions since it require a lot of testing.
Udalryk: Has a tag that is not viewable because of possibly too long tags? It should be "Cursed, Agent, Clan Brokvar" but we see just "Cursed, Agent,"
The Blacklist Button still covers the cards description, expecially now even more with a few cards. But is a general problem that can occour even in other languages.    