### PR TITLE
DIY-AI: fix English rendering in invariant mode

### DIFF
--- a/.github/workflows/diy-ai-ci.yml
+++ b/.github/workflows/diy-ai-ci.yml
@@ -84,9 +84,13 @@ jobs:
           network_name="gwent-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mongo_name="gwent-mongo-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           server_name="gwent-server-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cookie_jar=""
           cleanup() {
             docker rm --force "$server_name" "$mongo_name" >/dev/null 2>&1 || true
             docker network rm "$network_name" >/dev/null 2>&1 || true
+            if [[ -n "$cookie_jar" ]]; then
+              rm -f "$cookie_jar"
+            fi
           }
           trap cleanup EXIT
           docker network create "$network_name" >/dev/null
@@ -106,14 +110,53 @@ jobs:
             legacygwent-diy-ai:${GITHUB_SHA} >/dev/null
           host_port="$(docker port "$server_name" 5010/tcp | sed 's/.*://')"
           test -n "$host_port"
+          server_ready=0
           for _ in $(seq 1 20); do
             if curl --fail --silent --show-error "http://127.0.0.1:$host_port/healthz"; then
-              exit 0
+              server_ready=1
+              break
             fi
             sleep 1
           done
-          docker logs "$server_name"
-          exit 1
+          if [[ "$server_ready" != 1 ]]; then
+            docker logs "$server_name"
+            exit 1
+          fi
+
+          english_page="$(curl --fail --silent --show-error \
+            --header 'Accept-Language: en-US,en;q=0.9' \
+            "http://127.0.0.1:$host_port/")"
+          grep --fixed-strings --quiet '<html lang="en-US">' <<<"$english_page"
+          grep --fixed-strings --quiet 'Put Gwent back in players' <<<"$english_page"
+
+          fallback_page="$(curl --fail --silent --show-error \
+            --header 'Accept-Language: fr-FR' \
+            "http://127.0.0.1:$host_port/")"
+          grep --fixed-strings --quiet '<html lang="zh-CN">' <<<"$fallback_page"
+
+          default_page="$(curl --fail --silent --show-error \
+            "http://127.0.0.1:$host_port/")"
+          grep --fixed-strings --quiet '<html lang="zh-CN">' <<<"$default_page"
+
+          cookie_jar="$(mktemp)"
+          curl --silent --show-error --output /dev/null \
+            --cookie-jar "$cookie_jar" \
+            "http://127.0.0.1:$host_port/culture/set?culture=en-US&returnUrl=%2F"
+          cookie_page="$(curl --fail --silent --show-error \
+            --cookie "$cookie_jar" \
+            --header 'Accept-Language: zh-CN' \
+            "http://127.0.0.1:$host_port/")"
+          grep --fixed-strings --quiet '<html lang="en-US">' <<<"$cookie_page"
+
+          curl --silent --show-error --output /dev/null \
+            --cookie "$cookie_jar" \
+            --cookie-jar "$cookie_jar" \
+            "http://127.0.0.1:$host_port/culture/set?culture=zh-CN&returnUrl=%2F"
+          cookie_page="$(curl --fail --silent --show-error \
+            --cookie "$cookie_jar" \
+            --header 'Accept-Language: en-US' \
+            "http://127.0.0.1:$host_port/")"
+          grep --fixed-strings --quiet '<html lang="zh-CN">' <<<"$cookie_page"
 
   policy:
     runs-on: ubuntu-22.04

--- a/skills/legacy-gwent-maintainer/references/website-pitfalls.md
+++ b/skills/legacy-gwent-maintainer/references/website-pitfalls.md
@@ -94,6 +94,25 @@ Last verified: 2026-08-01
   and back, and require the exact path/query to remain while the language cookie
   and localized heading change.
 
+## Invariant globalization hides an otherwise correct English request culture
+
+- Symptom: browser language detection and the culture cookie work in the Windows
+  preview, but the .NET 10 Linux release always renders Chinese.
+- Cause: the legacy host must run with invariant globalization. The localization
+  middleware still selects a named `en-US` culture, but its
+  `TwoLetterISOLanguageName` is `iv`, not `en`.
+- Fix: identify the website language from the full BCP-47 culture `Name`
+  (`en-US`) in both `_Host.cshtml` and `SiteTextService`; keep the text service
+  stateless and singleton so prerender and interactive circuits cannot share
+  mutable language state.
+- Prevention: never infer a named culture from derived language properties when
+  the production runtime is invariant. Extend the runtime-image smoke test with
+  `Accept-Language`, unsupported-language fallback, and culture-cookie priority
+  assertions under the exact production globalization environment.
+- Verification: English headers render `lang="en-US"` and the English hero;
+  unsupported or absent headers fall back to `zh-CN`; English and Chinese
+  cookies each override the opposite request header.
+
 ## Hover states make nearby controls or navigation items jump
 
 - Symptom: a sidebar row, login button, or pager grows or changes shape on
@@ -135,8 +154,8 @@ Last verified: 2026-08-01
 - Prevention: restore downloads only from a manifest that records each exact
   filename, version, byte size, SHA-256, source commit, availability, and direct
   platform link. Never reuse the legacy shared folder as an AITest archive.
-- Verification: the website contains no folder ID or download route, direct
-  `/download` resolves to NotFound, `GetDownloadLink` is empty, and any future
+- Verification: the website contains no folder ID or download navigation,
+  direct `/download` returns 410 Gone, `GetDownloadLink` is empty, and any future
   published file reproduces the manifest hash.
 
 ## A public website trial inherits an unauthenticated admin mutation

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Pages/_Host.cshtml
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Pages/_Host.cshtml
@@ -2,11 +2,9 @@
 @namespace Cynthia.Card.Server.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @using System.Globalization
+@using Cynthia.Card.Server.Services
 @{
-    var isEnglish = string.Equals(
-        CultureInfo.CurrentUICulture.TwoLetterISOLanguageName,
-        "en",
-        StringComparison.OrdinalIgnoreCase);
+    var isEnglish = SiteTextService.IsEnglishCulture(CultureInfo.CurrentUICulture);
     var pageTitle = isEnglish ? "Gwent Workshop · AITest" : "昆特小窝 · AITest";
     var pageDescription = isEnglish
         ? "A Gwent test realm maintained by players and AI."

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/SiteTextService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/SiteTextService.cs
@@ -142,10 +142,15 @@ namespace Cynthia.Card.Server.Services
                 ["Monsters"] = ("怪兽", "Monsters")
             };
 
-        public bool IsEnglish => string.Equals(
-            CultureInfo.CurrentUICulture.TwoLetterISOLanguageName,
-            "en",
-            StringComparison.OrdinalIgnoreCase);
+        public bool IsEnglish => IsEnglishCulture(CultureInfo.CurrentUICulture);
+
+        public static bool IsEnglishCulture(CultureInfo culture)
+        {
+            return string.Equals(
+                culture?.Name,
+                "en-US",
+                StringComparison.OrdinalIgnoreCase);
+        }
 
         public string this[string key]
         {

--- a/src/Cynthia.Card/test/Cynthia.Card.Server.Tests/SiteTextServiceTests.cs
+++ b/src/Cynthia.Card/test/Cynthia.Card.Server.Tests/SiteTextServiceTests.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+using Cynthia.Card.Server.Services;
+using Xunit;
+
+namespace Cynthia.Card.Server.Tests
+{
+    public class SiteTextServiceTests
+    {
+        [Theory]
+        [InlineData("en-US", true)]
+        [InlineData("zh-CN", false)]
+        [InlineData("", false)]
+        public void EnglishDetectionUsesTheFullCultureName(
+            string cultureName,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                SiteTextService.IsEnglishCulture(new CultureInfo(cultureName)));
+        }
+    }
+}


### PR DESCRIPTION
Fix the production-only language regression after the .NET 10 launch. The Linux invariant runtime preserves CurrentUICulture.Name as en-US but reports TwoLetterISOLanguageName as iv. This PR switches both website language checks to the full culture name, adds unit coverage, extends the exact runtime-image smoke with header/fallback/cookie-precedence assertions, and records the pitfall. Local verification: 9/9 tests passed under invariant mode; live candidate returned en-US for English and zh-CN for unsupported/default, with both culture cookies overriding the opposite header. Scope is diy-ai only; no Unity or stable diy resources changed.