### PR TITLE
Fix the hall of fame page of the website

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/DatabaseMigrationService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/DatabaseMigrationService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Cynthia.Card.Server
+{
+    public class DatabaseMigrationService : BackgroundService
+    {
+        private readonly ILogger<DatabaseMigrationService> _logger;
+        private readonly GwentDatabaseService _databaseService;
+
+        public DatabaseMigrationService(
+            ILogger<DatabaseMigrationService> logger,
+            GwentDatabaseService databaseService)
+        {
+            _logger = logger;
+            _databaseService = databaseService;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                _logger.LogInformation("Running pending database migrations...");
+                await _databaseService.RunPendingMigrations();
+                _logger.LogInformation("Database migrations completed.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Database migration failed.");
+            }
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentDatabaseService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentDatabaseService.cs
@@ -31,6 +31,7 @@ namespace Cynthia.Card.Server
         }
         private IMongoDatabase GetDatabase() => GetMongoClient().GetDatabase(_dataBaseName);
         private IMongoCollection<UserInfo> GetUserInfo() => GetDatabase().GetCollection<UserInfo>(_repositoryName);
+        private IMongoCollection<BsonDocument> GetSettings() => GetDatabase().GetCollection<BsonDocument>("settings");
 
         public IMongoCollection<SeasonInfo> GetSeasonInfo() => GetDatabase().GetCollection<SeasonInfo>(_seasonRepositoryName);
 
@@ -803,10 +804,82 @@ namespace Cynthia.Card.Server
         {
             var filter = Builders<UserInfo>.Filter.Eq(x => x.UserName, username);
             var update = Builders<UserInfo>.Update
-                .Set(x => x.MMR, baseMMR)
-                .Set(x => x.HighestMMR, baseMMR);
+                .Set(x => x.MMR, baseMMR);
 
             await GetUserInfo().UpdateOneAsync(filter, update);
+        }
+
+        public async Task RunPendingMigrations()
+        {
+            const string migrationId = "restore_all_time_highest_mmr_v1";
+            if (await HasMigrationRunAsync(migrationId))
+            {
+                return;
+            }
+
+            await RestoreAllTimeHighestMMRFromSeasonHistoryAsync();
+            await MarkMigrationRunAsync(migrationId);
+        }
+
+        private async Task<bool> HasMigrationRunAsync(string migrationId)
+        {
+            var filter = Builders<BsonDocument>.Filter.Eq("key", migrationId);
+            var doc = await GetSettings().Find(filter).FirstOrDefaultAsync();
+            return doc != null && doc.Contains("value") && doc["value"].AsBoolean;
+        }
+
+        private async Task MarkMigrationRunAsync(string migrationId)
+        {
+            var filter = Builders<BsonDocument>.Filter.Eq("key", migrationId);
+            var update = Builders<BsonDocument>.Update
+                .Set("key", migrationId)
+                .Set("value", true);
+            await GetSettings().UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true });
+        }
+
+        private async Task RestoreAllTimeHighestMMRFromSeasonHistoryAsync()
+        {
+            var peaksByPlayer = new Dictionary<string, int>();
+
+            foreach (var season in QuerySeasons())
+            {
+                if (string.IsNullOrWhiteSpace(season.rankingHistory))
+                {
+                    continue;
+                }
+
+                foreach (var entry in Season.DecodeRanklist(season.rankingHistory))
+                {
+                    var playerName = entry.Item1;
+                    var historicalPeak = entry.Item6;
+                    if (peaksByPlayer.TryGetValue(playerName, out var existingPeak))
+                    {
+                        peaksByPlayer[playerName] = Math.Max(existingPeak, historicalPeak);
+                    }
+                    else
+                    {
+                        peaksByPlayer[playerName] = historicalPeak;
+                    }
+                }
+            }
+
+            foreach (var player in GetAllPlayers())
+            {
+                var restoredPeak = player.HighestMMR;
+                if (peaksByPlayer.TryGetValue(player.PlayerName, out var historicalPeak))
+                {
+                    restoredPeak = Math.Max(restoredPeak, historicalPeak);
+                }
+
+                if (restoredPeak <= player.HighestMMR)
+                {
+                    continue;
+                }
+
+                var filter = Builders<UserInfo>.Filter.Eq(x => x.UserName, player.UserName);
+                var update = Builders<UserInfo>.Update.Set(x => x.HighestMMR, restoredPeak);
+                await GetUserInfo().UpdateOneAsync(filter, update);
+            }
         }
         public async Task ResetPlayerStreak(string username)
         {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Startup.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Startup.cs
@@ -34,6 +34,7 @@ namespace Cynthia.Card.Server
             services.AddSingleton<Random>(x => new Random((int)DateTime.UtcNow.Ticks));
             // Add the scheduled event service
             services.AddHostedService<ScheduledEventService>();
+            services.AddHostedService<DatabaseMigrationService>();
             services.AddAntDesign();
             services.AddBlazoredLocalStorage();
             services.AddTransient<IMongoClient, MongoClient>(x => new MongoClient(GetConnectionString()));


### PR DESCRIPTION
Fix honor board (/rank2) showing season-only peaks instead of all-time records. Stop resetting HighestMMR on season rollover. On first deploy, automatically restore all-time peaks from archived season top-100 snapshots. No manual migration step required — runs on server startup.