### PR TITLE
feat(cards): publish August 30 third batch

### DIFF
--- a/skills/legacy-gwent-maintainer/references/august-30-batch-2026.md
+++ b/skills/legacy-gwent-maintainer/references/august-30-batch-2026.md
@@ -32,3 +32,10 @@ Last verified: 2026-08-30
   controller's turn, it finds every tied weakest other allied Witcher and
   Boosts each by 1, then independently recalculates the current weakest set and
   repeats once. Exclude Coën itself even if its own power is the lowest.
+- CardMap `1.0.0.192` raises Endrega Queen `70199` from 2 to 3 base power and
+  Sir Scratch-a-Lot `70177` from 3 to 7 base power.
+- Dandelion: Vainglory `12011` counts qualifying cards in the starting deck by
+  their established character `HideTag` values. Zoltan: Warrior `70019` and
+  Zoltan's Company `70167` therefore carry `HideTag.Zoltan`; each contributes
+  one 3-point Boost to Dandelion. Unrelated starting-deck cards do not count,
+  and the existing player text remains unchanged.

--- a/skills/legacy-gwent-maintainer/references/index.md
+++ b/skills/legacy-gwent-maintainer/references/index.md
@@ -13,7 +13,7 @@ Read this file first, then load only the rows relevant to the task.
 | August 6 Nilfgaard/global card batch | [nilfgaard-batch-august-2026.md](nilfgaard-batch-august-2026.md) | Restored pool, effects, rounding rule, and regressions |
 | August 7 Northern Realms/global card batch | [northern-realms-batch-august-2026.md](northern-realms-batch-august-2026.md) | Restored pool, delayed effects, armor transfer, and lock timing |
 | August 13 card batch | [august-13-batch-2026.md](august-13-batch-2026.md) | War Council Truce split, Cerys discard lifecycle, Living Armor rarity |
-| August 30 card batches | [august-30-batch-2026.md](august-30-batch-2026.md) | Egmond end-turn repeat, Coën recalculation, visible Countdowns, Queen Adalia |
+| August 30 card batches | [august-30-batch-2026.md](august-30-batch-2026.md) | Egmond/Coën timing, visible Countdowns, Queen Adalia, Dandelion character tags |
 | Deployment, landing, damage, shield, duel, repeated effects | [gameplay-lifecycle.md](gameplay-lifecycle.md) | Server gameplay pipeline and timing boundaries |
 | Complex card effects, headless matches, deterministic scenarios | [testing.md](testing.md) | Isolated in-process gameplay tests and fixture |
 | Card-batch publication, preflight, repeated CI | [release-preflight.md](release-preflight.md) | First-push gates and release-loop prevention |

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 191);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 192);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 
@@ -11539,6 +11539,7 @@ namespace Cynthia.Card
                     IsCountdown = false,
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Dwarf},
+                    HideTags = new HideTag[]{ HideTag.Zoltan },
                     Flavor = "",
                     Info = "召唤“菲吉斯·梅鲁佐”和“穆罗·布鲁伊斯”，自身受到强化时额外获得1点强化。",
                     CardArtsId = "202467",
@@ -14728,6 +14729,7 @@ namespace Cynthia.Card
                     IsCountdown = false,
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Special,Categorie.Tactic},
+                    HideTags = new HideTag[]{ HideTag.Zoltan },
                     Flavor = "",
                     Info = "将墓场中至多3张铜色/银色“矮人”牌返回牌组，随后从牌组打出1张铜色“矮人”牌。",
                     CardArtsId = "202471",
@@ -14930,7 +14932,7 @@ namespace Cynthia.Card
                 {
                     CardId ="70177", //Sir Scratch-a-Lot
                     Name="挠挠爵士",
-                    Strength=3,
+                    Strength=7,
                     Group=Group.Gold,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -15522,7 +15524,7 @@ namespace Cynthia.Card
                 {
                     CardId = "70199",
                     Name = "安德莱格女王",
-                    Strength = 2,
+                    Strength = 3,
                     Group = Group.Gold,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,

--- a/src/Cynthia.Card/test/Cynthia.Card.Gameplay.Tests/AugustThirtiethThirdBatchTests.cs
+++ b/src/Cynthia.Card/test/Cynthia.Card.Gameplay.Tests/AugustThirtiethThirdBatchTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cynthia.Card.Gameplay.Tests
+{
+    public class AugustThirtiethThirdBatchTests
+    {
+        [Fact]
+        public async Task DandelionVaingloryCountsBothNewZoltanCardsInTheStartingDeck()
+        {
+            var fixture = new HeadlessGameFixture();
+            var dandelion = fixture.AddCard(
+                fixture.Game.Player1Index,
+                CardId.DandelionVainglory,
+                RowPosition.MyRow1);
+            fixture.Game.PlayerBaseDeck[fixture.Game.Player1Index].Deck = new List<GwentCard>
+            {
+                GwentMap.CardMap[CardId.ZoltanWarrior],
+                GwentMap.CardMap[CardId.ZoltansCompany],
+                GwentMap.CardMap[CardId.Wolf]
+            };
+            await fixture.SynchronizeClientsAsync();
+
+            await fixture.Game.AddTask(
+                () => dandelion.Effects.RaiseEvent(new CardPlayEffect(false, false)));
+
+            Assert.Equal(6, dandelion.Status.HealthStatus);
+        }
+
+        [Fact]
+        public async Task DandelionVaingloryDoesNotCountUnrelatedStartingDeckCards()
+        {
+            var fixture = new HeadlessGameFixture();
+            var dandelion = fixture.AddCard(
+                fixture.Game.Player1Index,
+                CardId.DandelionVainglory,
+                RowPosition.MyRow1);
+            fixture.Game.PlayerBaseDeck[fixture.Game.Player1Index].Deck = new List<GwentCard>
+            {
+                GwentMap.CardMap[CardId.DwarfMiner],
+                GwentMap.CardMap[CardId.Wolf]
+            };
+            await fixture.SynchronizeClientsAsync();
+
+            await fixture.Game.AddTask(
+                () => dandelion.Effects.RaiseEvent(new CardPlayEffect(false, false)));
+
+            Assert.Equal(0, dandelion.Status.HealthStatus);
+        }
+    }
+}

--- a/src/Cynthia.Card/test/Cynthia.Card.Server.Tests/DiyAiCardPoolTests.cs
+++ b/src/Cynthia.Card/test/Cynthia.Card.Server.Tests/DiyAiCardPoolTests.cs
@@ -41,7 +41,7 @@ namespace Cynthia.Card.Server.Tests
         [Fact]
         public void CardMapOrdinalOrderRemainsHistoricalDecodeCompatible()
         {
-            Assert.Equal(new Version(1, 0, 0, 191), GwentMap.CardMapVersion);
+            Assert.Equal(new Version(1, 0, 0, 192), GwentMap.CardMapVersion);
             Assert.Equal(725, GwentMap.CardMap.Count);
 
             var historicalIds = string.Join(",", GwentMap.CardMap.Keys.Take(709));
@@ -54,6 +54,26 @@ namespace Cynthia.Card.Server.Tests
             Assert.Equal(
                 new[] { "34034", "34035", "34036", "64035", "64036", "64037", "70191", "70192", "70193", "70194", "70195", "70196", "70197", "70198", "70199", "70200" },
                 GwentMap.CardMap.Keys.Skip(709));
+        }
+
+        [Fact]
+        public void AugustThirtiethThirdBatchMatchesPublishedRules()
+        {
+            Assert.Equal(3, GwentMap.CardMap[CardId.EndregaQueen].Strength);
+            Assert.Equal(7, GwentMap.CardMap[CardId.SirScratchALot].Strength);
+
+            Assert.Contains(
+                HideTag.Zoltan,
+                GwentMap.CardMap[CardId.ZoltanWarrior].HideTags);
+            Assert.Contains(
+                HideTag.Zoltan,
+                GwentMap.CardMap[CardId.ZoltansCompany].HideTags);
+            Assert.DoesNotContain(
+                HideTag.Zoltan,
+                GwentMap.CardMap[CardId.DwarfMiner].HideTags ?? Array.Empty<HideTag>());
+            Assert.Equal(
+                "己方起始牌组中每有1张“杰洛特”、“叶奈法”、“特莉丝”或“卓尔坦”牌，便获得3点增益。",
+                GwentMap.CardMap[CardId.DandelionVainglory].Info);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- raise Endrega Queen from 2 to 3 power
- raise Sir Scratch-a-Lot from 3 to 7 power
- make Zoltan: Warrior and Zoltan's Company count for Dandelion: Vainglory without changing player text
- add positive and negative regression coverage and update durable card-batch knowledge

## Local verification
- targeted Gameplay tests: 2/2
- Server.Tests: 44/44
- Gameplay.Tests: 136/136
- Release server build: 0 warnings, 0 errors
- git diff --check
- knowledge validation and skill quick validation